### PR TITLE
Fix share and settings icon centering in user profile

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -480,7 +480,7 @@ function UserProfileContent() {
                             navigator.clipboard.writeText(profileUrl)
                             toast.success('Profile link copied!')
                           }}
-                          className="p-2 rounded-full border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                          className="p-2 rounded-full border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors flex items-center justify-center"
                         >
                           <ShareIcon className="h-4 w-4" />
                         </button>
@@ -501,7 +501,7 @@ function UserProfileContent() {
                         <Tooltip.Trigger asChild>
                           <button
                             onClick={() => router.push('/settings')}
-                            className="p-2 rounded-full border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                            className="p-2 rounded-full border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors flex items-center justify-center"
                           >
                             <Cog6ToothIcon className="h-4 w-4" />
                           </button>


### PR DESCRIPTION
Add flex centering (flex items-center justify-center) to the circular icon buttons to ensure icons are properly centered within the button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved icon alignment and centering in the Share and Settings action buttons for better visual appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->