### PR TITLE
Fix reply posting error by passing post IDs as base58 strings

### DIFF
--- a/lib/dash-platform-client.ts
+++ b/lib/dash-platform-client.ts
@@ -117,28 +117,14 @@ export class DashPlatformClient {
         content: content.trim()
       }
       
-      // Convert replyToPostId if provided
+      // Pass replyToPostId as base58 string (SDK handles conversion)
       if (options?.replyToPostId) {
-        try {
-          const bs58Module = await import('bs58')
-          const bs58 = bs58Module.default
-          postData.replyToPostId = Array.from(bs58.decode(options.replyToPostId))
-        } catch (e) {
-          console.error('Failed to decode replyToPostId:', e)
-          throw new Error('Invalid reply post ID format')
-        }
+        postData.replyToPostId = options.replyToPostId
       }
 
-      // Convert quotedPostId if provided
+      // Pass quotedPostId as base58 string (SDK handles conversion)
       if (options?.quotedPostId) {
-        try {
-          const bs58Module = await import('bs58')
-          const bs58 = bs58Module.default
-          postData.quotedPostId = Array.from(bs58.decode(options.quotedPostId))
-        } catch (e) {
-          console.error('Failed to decode quotedPostId:', e)
-          throw new Error('Invalid quoted post ID format')
-        }
+        postData.quotedPostId = options.quotedPostId
       }
       
       // Add other optional fields

--- a/lib/services/like-service.ts
+++ b/lib/services/like-service.ts
@@ -1,6 +1,6 @@
 import { BaseDocumentService, QueryOptions } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { identifierToBase58, stringToIdentifierBytes, normalizeSDKResponse, RequestDeduplicator } from './sdk-helpers';
+import { identifierToBase58, stringToIdentifierBytes, normalizeSDKResponse, RequestDeduplicator, base58ArrayToBytes } from './sdk-helpers';
 
 export interface LikeDocument {
   $id: string;
@@ -225,10 +225,14 @@ class LikeService extends BaseDocumentService<LikeDocument> {
 
       // Use 'in' operator for batch query on postId
       // Must include orderBy to match the postLikes index: [postId, $createdAt]
+      // Convert base58 strings to byte arrays for the byte array field
+      const postIdBytes = base58ArrayToBytes(postIds);
+      if (postIdBytes.length === 0) return [];
+
       const response = await sdk.documents.query({
         dataContractId: this.contractId,
         documentTypeName: 'like',
-        where: [['postId', 'in', postIds]],
+        where: [['postId', 'in', postIdBytes]],
         orderBy: [['postId', 'asc']],
         limit: 100
       } as any);

--- a/lib/services/repost-service.ts
+++ b/lib/services/repost-service.ts
@@ -1,6 +1,6 @@
 import { BaseDocumentService, QueryOptions } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { identifierToBase58, stringToIdentifierBytes, normalizeSDKResponse } from './sdk-helpers';
+import { identifierToBase58, stringToIdentifierBytes, normalizeSDKResponse, base58ArrayToBytes } from './sdk-helpers';
 
 export interface RepostDocument {
   $id: string;
@@ -186,10 +186,14 @@ class RepostService extends BaseDocumentService<RepostDocument> {
 
       // Use 'in' operator for batch query on postId
       // Must include orderBy to match the postReposts index: [postId, $createdAt]
+      // Convert base58 strings to byte arrays for the byte array field
+      const postIdBytes = base58ArrayToBytes(postIds);
+      if (postIdBytes.length === 0) return [];
+
       const response = await sdk.documents.query({
         dataContractId: this.contractId,
         documentTypeName: 'repost',
-        where: [['postId', 'in', postIds]],
+        where: [['postId', 'in', postIdBytes]],
         orderBy: [['postId', 'asc']],
         limit: 100
       } as any);


### PR DESCRIPTION
The createPost method was incorrectly decoding replyToPostId and quotedPostId from base58 strings to byte arrays before sending to the SDK. This caused the "could not be decoded from base 58" error because the SDK expects these fields as base58 strings, not byte arrays.

Removed the bs58 decoding logic and now pass the IDs directly as strings, matching how the SDK handles them in query operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Post creation now passes reply and quoted IDs through unchanged.

* **Bug Fixes**
  * Likes, reposts and replies fetching now handles empty or missing IDs gracefully and avoids unnecessary queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->