### PR TITLE
Fix user page to show newest posts first

### DIFF
--- a/lib/services/post-service.ts
+++ b/lib/services/post-service.ts
@@ -581,18 +581,16 @@ class PostService extends BaseDocumentService<Post> {
    */
   async getUserPosts(userId: string, options: QueryOptions = {}): Promise<DocumentResult<Post>> {
     const queryOptions: QueryOptions = {
-      where: [['$ownerId', '==', userId]],
-      orderBy: [['$ownerId', 'asc'], ['$createdAt', 'asc']],
+      where: [
+        ['$ownerId', '==', userId],
+        ['$createdAt', '>', 0]
+      ],
+      orderBy: [['$ownerId', 'asc'], ['$createdAt', 'desc']],
       limit: 20,
       ...options
     };
 
-    const result = await this.query(queryOptions);
-
-    // Sort by createdAt descending (platform returns in index order which is asc)
-    result.documents.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-
-    return result;
+    return this.query(queryOptions);
   }
 
   /**

--- a/lib/services/repost-service.ts
+++ b/lib/services/repost-service.ts
@@ -154,7 +154,7 @@ class RepostService extends BaseDocumentService<RepostDocument> {
           ['$ownerId', '==', userId],
           ['$createdAt', '>', 0]
         ],
-        orderBy: [['$createdAt', 'asc']],
+        orderBy: [['$createdAt', 'desc']],
         limit: 50,
         ...options
       });


### PR DESCRIPTION
The getUserPosts and getUserReposts queries were ordering by $createdAt ascending with a limit, causing them to return the oldest posts instead of the newest. Changed to desc ordering so active users see their most recent content on their profile page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Posts and reposts now display in reverse chronological order, showing newest content first.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->