### PR TITLE
Implement comprehensive account deletion flow

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -132,14 +132,28 @@ export default function PrivacyPage() {
               </p>
             </section>
 
-            {/* No Deletion */}
+            {/* Data Deletion */}
             <section>
-              <h2 className="text-xl font-semibold mb-3">Data Cannot Be Deleted</h2>
-              <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
-                Because data is stored on a blockchain, it cannot be deleted. There is no &quot;delete my account&quot;
-                button because no one has the power to remove data from the blockchain. Once you post something,
-                it exists permanently. This is a fundamental property of blockchain technology, not a choice we made.
-              </p>
+              <h2 className="text-xl font-semibold mb-3">Data Deletion</h2>
+              <div className="text-gray-600 dark:text-gray-400 leading-relaxed space-y-3">
+                <p>
+                  <strong>You can delete your account</strong> and all associated data from Dash Platform. Unlike traditional
+                  blockchains, Dash Platform documents can be deleted by their owners. When you delete your account:
+                </p>
+                <ul className="list-disc list-inside space-y-1 ml-2">
+                  <li>All your posts, likes, reposts, and replies are permanently removed</li>
+                  <li>Your profile and avatar are deleted</li>
+                  <li>Your follow lists, bookmarks, and blocks are removed</li>
+                  <li>Your direct messages are deleted</li>
+                </ul>
+                <div className="bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded-lg p-4 mt-4">
+                  <p className="text-amber-800 dark:text-amber-200 text-sm">
+                    <strong>Important:</strong> While data is deleted from Dash Platform itself, third-party services such as
+                    blockchain explorers, indexing platforms, or archive services may have copied your data before deletion.
+                    We have no control over these external services, and they may retain historical copies of your content.
+                  </p>
+                </div>
+              </div>
             </section>
 
             {/* Third Parties */}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -26,11 +26,12 @@ import * as Switch from '@radix-ui/react-switch'
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import toast from 'react-hot-toast'
 import { KeyBackupSettings } from '@/components/settings/key-backup-settings'
 import { BlockedUsersSettings } from '@/components/settings/blocked-users'
 import { BlockListSettings } from '@/components/settings/block-list-settings'
 import { useDashPayContactsModal } from '@/hooks/use-dashpay-contacts-modal'
+import { useDeleteAccountModal } from '@/hooks/use-delete-account-modal'
+import { DeleteAccountModal } from '@/components/settings/delete-account-modal'
 
 type SettingsSection = 'main' | 'account' | 'contacts' | 'notifications' | 'privacy' | 'appearance' | 'about'
 const VALID_SECTIONS: SettingsSection[] = ['main', 'account', 'contacts', 'notifications', 'privacy', 'appearance', 'about']
@@ -117,11 +118,10 @@ function SettingsPage() {
     }
   }
 
-  // TODO: Implement account deletion
+  // Delete account modal
+  const { open: openDeleteAccountModal } = useDeleteAccountModal()
   const handleDeleteAccount = () => {
-    if (confirm('Are you sure you want to delete your account? This action cannot be undone.')) {
-      toast.error('Account deletion is not yet implemented')
-    }
+    openDeleteAccountModal()
   }
 
   const renderMainSettings = () => (
@@ -529,6 +529,7 @@ function SettingsPage() {
 
   return (
     <div className="min-h-[calc(100vh-40px)] flex">
+      <DeleteAccountModal />
       <Sidebar />
 
       <div className="flex-1 flex justify-center min-w-0">

--- a/components/settings/delete-account-modal.tsx
+++ b/components/settings/delete-account-modal.tsx
@@ -1,0 +1,546 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { X, Loader2, AlertTriangle, Trash2, CheckCircle, XCircle } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useDeleteAccountModal } from '@/hooks/use-delete-account-modal'
+import { useAuth } from '@/contexts/auth-context'
+import { accountDeletionService, DeletionProgress } from '@/lib/services/account-deletion-service'
+
+/**
+ * Delete Account Modal
+ *
+ * Multi-step modal for permanent account deletion:
+ * 1. Warning - explain what will be deleted
+ * 2. Confirm - type "DELETE" to confirm
+ * 3. Progress - show deletion progress
+ * 4. Complete/Error - show result
+ */
+export function DeleteAccountModal() {
+  const router = useRouter()
+  const { user } = useAuth()
+  const {
+    isOpen,
+    step,
+    progress,
+    result,
+    documentCounts,
+    isLoadingCounts,
+    setStep,
+    setProgress,
+    setResult,
+    setDocumentCounts,
+    setIsLoadingCounts,
+    reset
+  } = useDeleteAccountModal()
+
+  const [confirmText, setConfirmText] = useState('')
+  const [understood, setUnderstood] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  // Load document counts when modal opens
+  useEffect(() => {
+    const loadCounts = async () => {
+      if (!user?.identityId) return
+
+      setIsLoadingCounts(true)
+      try {
+        const counts = await accountDeletionService.countUserDocuments(user.identityId)
+        setDocumentCounts(counts)
+      } catch (error) {
+        console.error('Failed to load document counts:', error)
+        // Continue anyway - counts are just informational
+        setDocumentCounts({})
+      } finally {
+        setIsLoadingCounts(false)
+      }
+    }
+
+    if (isOpen && step === 'warning' && user?.identityId && documentCounts === null && !isLoadingCounts) {
+      void loadCounts()
+    }
+  }, [isOpen, step, user?.identityId, documentCounts, isLoadingCounts, setIsLoadingCounts, setDocumentCounts])
+
+  const handleClose = () => {
+    if (isDeleting) return // Prevent closing during deletion
+    setConfirmText('')
+    setUnderstood(false)
+    reset()
+  }
+
+  const handleStartDeletion = async () => {
+    if (!user?.identityId) return
+
+    setIsDeleting(true)
+    setStep('progress')
+
+    try {
+      const deletionResult = await accountDeletionService.deleteAccount(
+        user.identityId,
+        (progressUpdate: DeletionProgress) => {
+          setProgress(progressUpdate)
+        }
+      )
+
+      setResult(deletionResult)
+
+      if (deletionResult.success) {
+        setStep('complete')
+      } else if (deletionResult.partialFailure) {
+        setStep('error')
+      } else {
+        setStep('error')
+      }
+    } catch (error) {
+      console.error('Deletion failed:', error)
+      setResult({
+        success: false,
+        totalDeleted: 0,
+        totalFailed: 0,
+        errors: [{
+          contractId: 'unknown',
+          documentType: 'unknown',
+          documentId: 'unknown',
+          error: error instanceof Error ? error.message : 'Unknown error'
+        }],
+        partialFailure: false
+      })
+      setStep('error')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  const handleCompleteLogout = () => {
+    handleClose()
+    router.push('/login')
+  }
+
+  const getTotalDocuments = () => {
+    if (!documentCounts) return 0
+    return Object.values(documentCounts).reduce((sum, count) => sum + count, 0)
+  }
+
+  const deletionSummary = accountDeletionService.getDeletionSummary()
+
+  // Render warning step
+  const renderWarningStep = () => (
+    <div className="space-y-4">
+      {/* Icon */}
+      <div className="flex justify-center">
+        <div className="w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+          <Trash2 className="w-8 h-8 text-red-600 dark:text-red-400" />
+        </div>
+      </div>
+
+      <h2 className="text-xl font-bold text-center">Delete Your Account</h2>
+
+      <p className="text-gray-600 dark:text-gray-400 text-center text-sm">
+        This will permanently delete all your data from Dash Platform.
+      </p>
+
+      {/* Document counts */}
+      {isLoadingCounts ? (
+        <div className="bg-gray-50 dark:bg-gray-950 rounded-lg p-4 text-center">
+          <Loader2 className="w-5 h-5 animate-spin mx-auto mb-2" />
+          <p className="text-sm text-gray-500">Counting your documents...</p>
+        </div>
+      ) : documentCounts && getTotalDocuments() > 0 ? (
+        <div className="bg-gray-50 dark:bg-gray-950 rounded-lg p-4">
+          <p className="text-sm font-medium mb-2">
+            You have <span className="text-red-600 dark:text-red-400">{getTotalDocuments()}</span> documents to delete:
+          </p>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            {Object.entries(documentCounts).map(([type, count]) => (
+              <div key={type} className="flex justify-between">
+                <span className="text-gray-500 capitalize">{type.replace(/([A-Z])/g, ' $1').trim()}</span>
+                <span className="font-mono">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {/* What will be deleted */}
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+        <h3 className="font-semibold text-red-800 dark:text-red-200 mb-2 text-sm flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4" />
+          What will be deleted:
+        </h3>
+        <div className="space-y-2">
+          {deletionSummary.map((category) => (
+            <div key={category.category}>
+              <p className="text-xs font-medium text-red-700 dark:text-red-300">{category.category}</p>
+              <ul className="text-xs text-red-600 dark:text-red-400 ml-4 list-disc">
+                {category.items.map((item, i) => (
+                  <li key={i}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Third-party warning */}
+      <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+          <div className="text-sm">
+            <p className="font-semibold text-amber-800 dark:text-amber-200 mb-1">
+              Important Notice
+            </p>
+            <p className="text-amber-700 dark:text-amber-300 text-xs">
+              While your data will be deleted from Dash Platform, <strong>third-party indexers or explorers may retain historical copies</strong>.
+              The blockchain itself doesn&apos;t keep document history, but external services that have indexed your data may still have copies.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Consent checkbox */}
+      <label className="flex items-start gap-3 cursor-pointer p-3 rounded-lg border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-950 transition-colors">
+        <input
+          type="checkbox"
+          checked={understood}
+          onChange={(e) => setUnderstood(e.target.checked)}
+          className="mt-1 h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300 rounded"
+        />
+        <span className="text-sm text-gray-700 dark:text-gray-300">
+          I understand this action is <strong>permanent</strong> and cannot be undone
+        </span>
+      </label>
+
+      <div className="flex gap-3 pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          onClick={handleClose}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          className="flex-1 bg-red-600 hover:bg-red-700 text-white"
+          disabled={!understood || isLoadingCounts}
+          onClick={() => setStep('confirm')}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  )
+
+  // Render confirm step
+  const renderConfirmStep = () => (
+    <div className="space-y-4">
+      <div className="flex justify-center">
+        <div className="w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+          <AlertTriangle className="w-8 h-8 text-red-600 dark:text-red-400" />
+        </div>
+      </div>
+
+      <h2 className="text-xl font-bold text-center">Confirm Deletion</h2>
+
+      <p className="text-gray-600 dark:text-gray-400 text-center text-sm">
+        To confirm, type <strong className="text-red-600">DELETE</strong> below
+      </p>
+
+      <div>
+        <input
+          type="text"
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value.toUpperCase())}
+          placeholder="Type DELETE to confirm"
+          className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-lg text-center text-lg font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-colors"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="characters"
+        />
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          onClick={() => {
+            setConfirmText('')
+            setStep('warning')
+          }}
+        >
+          Go Back
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          className="flex-1 bg-red-600 hover:bg-red-700 text-white"
+          disabled={confirmText !== 'DELETE'}
+          onClick={handleStartDeletion}
+        >
+          Delete My Account
+        </Button>
+      </div>
+    </div>
+  )
+
+  // Render progress step
+  const renderProgressStep = () => {
+    const progressPercent = progress
+      ? Math.round((progress.processedDocuments / Math.max(progress.totalDocuments, 1)) * 100)
+      : 0
+
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-center">
+          <div className="w-16 h-16 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+            <Loader2 className="w-8 h-8 text-blue-600 dark:text-blue-400 animate-spin" />
+          </div>
+        </div>
+
+        <h2 className="text-xl font-bold text-center">Deleting Your Data</h2>
+
+        <p className="text-gray-600 dark:text-gray-400 text-center text-sm">
+          Please wait while we delete your documents...
+        </p>
+
+        {/* Progress bar */}
+        <div className="space-y-2">
+          <div className="h-3 bg-gray-200 dark:bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-blue-600 transition-all duration-300 ease-out"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <p className="text-sm text-center text-gray-500">
+            {progress?.processedDocuments || 0} / {progress?.totalDocuments || 0} documents processed
+          </p>
+        </div>
+
+        {/* Current operation */}
+        {progress && (
+          <div className="bg-gray-50 dark:bg-gray-950 rounded-lg p-4 text-center">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {progress.phase === 'counting' && 'Counting documents...'}
+              {progress.phase === 'deleting' && (
+                <>Deleting {progress.currentDocumentType} from {progress.currentContract}...</>
+              )}
+              {progress.phase === 'cleanup' && 'Cleaning up local data...'}
+            </p>
+          </div>
+        )}
+
+        {/* Stats */}
+        {progress && progress.processedDocuments > 0 && (
+          <div className="flex justify-center gap-6 text-sm">
+            <div className="text-center">
+              <p className="text-green-600 dark:text-green-400 font-semibold">{progress.deletedDocuments}</p>
+              <p className="text-gray-500 text-xs">Deleted</p>
+            </div>
+            {progress.failedDocuments > 0 && (
+              <div className="text-center">
+                <p className="text-red-600 dark:text-red-400 font-semibold">{progress.failedDocuments}</p>
+                <p className="text-gray-500 text-xs">Failed</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        <p className="text-xs text-center text-gray-400">
+          Do not close this window
+        </p>
+      </div>
+    )
+  }
+
+  // Render complete step
+  const renderCompleteStep = () => (
+    <div className="space-y-4">
+      <div className="flex justify-center">
+        <div className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
+          <CheckCircle className="w-8 h-8 text-green-600 dark:text-green-400" />
+        </div>
+      </div>
+
+      <h2 className="text-xl font-bold text-center">Account Deleted</h2>
+
+      <p className="text-gray-600 dark:text-gray-400 text-center text-sm">
+        Your account data has been successfully deleted from Dash Platform.
+      </p>
+
+      {result && (
+        <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4 text-center">
+          <p className="text-green-700 dark:text-green-300 font-semibold">
+            {result.totalDeleted} documents deleted
+          </p>
+        </div>
+      )}
+
+      <Button
+        type="button"
+        className="w-full"
+        onClick={handleCompleteLogout}
+      >
+        Return to Login
+      </Button>
+    </div>
+  )
+
+  // Render error step
+  const renderErrorStep = () => (
+    <div className="space-y-4">
+      <div className="flex justify-center">
+        <div className="w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+          <XCircle className="w-8 h-8 text-red-600 dark:text-red-400" />
+        </div>
+      </div>
+
+      <h2 className="text-xl font-bold text-center">
+        {result?.partialFailure ? 'Partial Deletion' : 'Deletion Failed'}
+      </h2>
+
+      <p className="text-gray-600 dark:text-gray-400 text-center text-sm">
+        {result?.partialFailure
+          ? 'Some documents could not be deleted. You may try again later.'
+          : 'We encountered an error while deleting your data.'}
+      </p>
+
+      {result && (
+        <div className="space-y-2">
+          {result.totalDeleted > 0 && (
+            <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-3 text-center">
+              <p className="text-green-700 dark:text-green-300 text-sm">
+                {result.totalDeleted} documents successfully deleted
+              </p>
+            </div>
+          )}
+
+          {result.totalFailed > 0 && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+              <p className="text-red-700 dark:text-red-300 text-sm text-center mb-2">
+                {result.totalFailed} documents failed to delete
+              </p>
+              {result.errors.length > 0 && result.errors.length <= 5 && (
+                <ul className="text-xs text-red-600 dark:text-red-400 space-y-1">
+                  {result.errors.map((err, i) => (
+                    <li key={i} className="truncate">
+                      {err.documentType}: {err.error}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-3 pt-2">
+        {result?.partialFailure ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              onClick={handleCompleteLogout}
+            >
+              Continue Anyway
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              className="flex-1 bg-red-600 hover:bg-red-700 text-white"
+              onClick={() => {
+                setConfirmText('')
+                setStep('warning')
+              }}
+            >
+              Try Again
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              onClick={handleClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              className="flex-1 bg-red-600 hover:bg-red-700 text-white"
+              onClick={() => {
+                setConfirmText('')
+                setStep('warning')
+              }}
+            >
+              Try Again
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+
+  const renderStep = () => {
+    switch (step) {
+      case 'warning':
+        return renderWarningStep()
+      case 'confirm':
+        return renderConfirmStep()
+      case 'progress':
+        return renderProgressStep()
+      case 'complete':
+        return renderCompleteStep()
+      case 'error':
+        return renderErrorStep()
+      default:
+        return renderWarningStep()
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50"
+            onClick={isDeleting ? undefined : handleClose}
+          />
+
+          {/* Modal */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 flex items-center justify-center z-50 px-4 overflow-y-auto py-8"
+          >
+            <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-6 max-w-md w-full relative my-auto">
+              {/* Close button - hidden during deletion */}
+              {!isDeleting && step !== 'progress' && (
+                <button
+                  onClick={handleClose}
+                  className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                >
+                  <X className="w-5 h-5" />
+                </button>
+              )}
+
+              {renderStep()}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/components/settings/delete-account-modal.tsx
+++ b/components/settings/delete-account-modal.tsx
@@ -20,7 +20,7 @@ import { accountDeletionService, DeletionProgress } from '@/lib/services/account
  */
 export function DeleteAccountModal() {
   const router = useRouter()
-  const { user } = useAuth()
+  const { user, logout } = useAuth()
   const {
     isOpen,
     step,
@@ -113,9 +113,16 @@ export function DeleteAccountModal() {
     }
   }
 
-  const handleCompleteLogout = () => {
-    handleClose()
-    router.push('/login')
+  const handleCompleteLogout = async () => {
+    try {
+      await logout()
+    } catch (error) {
+      console.error('Failed to logout after account deletion:', error)
+      // Navigate to login even if logout fails
+      router.push('/login')
+    } finally {
+      handleClose()
+    }
   }
 
   const getTotalDocuments = () => {

--- a/hooks/use-delete-account-modal.ts
+++ b/hooks/use-delete-account-modal.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import { DeletionProgress, DeletionResult, DocumentCounts } from '@/lib/services/account-deletion-service'
+
+export type DeleteAccountStep = 'warning' | 'confirm' | 'progress' | 'complete' | 'error'
+
+interface DeleteAccountModalStore {
+  isOpen: boolean
+  step: DeleteAccountStep
+  progress: DeletionProgress | null
+  result: DeletionResult | null
+  documentCounts: DocumentCounts | null
+  isLoadingCounts: boolean
+
+  // Actions
+  open: () => void
+  close: () => void
+  setStep: (step: DeleteAccountStep) => void
+  setProgress: (progress: DeletionProgress) => void
+  setResult: (result: DeletionResult) => void
+  setDocumentCounts: (counts: DocumentCounts) => void
+  setIsLoadingCounts: (loading: boolean) => void
+  reset: () => void
+}
+
+const initialState = {
+  isOpen: false,
+  step: 'warning' as DeleteAccountStep,
+  progress: null,
+  result: null,
+  documentCounts: null,
+  isLoadingCounts: false
+}
+
+export const useDeleteAccountModal = create<DeleteAccountModalStore>((set) => ({
+  ...initialState,
+
+  open: () => set({ isOpen: true, step: 'warning' }),
+
+  close: () => set({ isOpen: false }),
+
+  setStep: (step) => set({ step }),
+
+  setProgress: (progress) => set({ progress }),
+
+  setResult: (result) => set({ result }),
+
+  setDocumentCounts: (documentCounts) => set({ documentCounts }),
+
+  setIsLoadingCounts: (isLoadingCounts) => set({ isLoadingCounts }),
+
+  reset: () => set(initialState)
+}))

--- a/lib/services/account-deletion-service.ts
+++ b/lib/services/account-deletion-service.ts
@@ -1,0 +1,487 @@
+import { getEvoSdk } from './evo-sdk-service'
+import { stateTransitionService } from './state-transition-service'
+import {
+  YAPPR_CONTRACT_ID,
+  YAPPR_PROFILE_CONTRACT_ID,
+  YAPPR_DM_CONTRACT_ID,
+  YAPPR_BLOCK_CONTRACT_ID,
+  ENCRYPTED_KEY_BACKUP_CONTRACT_ID,
+  HASHTAG_CONTRACT_ID
+} from '../constants'
+
+/**
+ * Registry entry for a contract and its deletable document types
+ */
+interface DeletionRegistry {
+  contractId: string
+  documentTypes: string[]
+  serviceName: string
+}
+
+/**
+ * Information about a document to be deleted
+ */
+interface DocumentInfo {
+  $id: string
+  $ownerId: string
+  documentType: string
+  contractId: string
+}
+
+/**
+ * Progress update during deletion
+ */
+export interface DeletionProgress {
+  phase: 'counting' | 'deleting' | 'cleanup' | 'complete' | 'failed'
+  currentContract: string
+  currentDocumentType: string
+  totalDocuments: number
+  processedDocuments: number
+  deletedDocuments: number
+  failedDocuments: number
+  errors: Array<{
+    contractId: string
+    documentType: string
+    documentId: string
+    error: string
+  }>
+}
+
+/**
+ * Result of account deletion
+ */
+export interface DeletionResult {
+  success: boolean
+  totalDeleted: number
+  totalFailed: number
+  errors: DeletionProgress['errors']
+  partialFailure: boolean
+}
+
+/**
+ * Document counts by type for display
+ */
+export interface DocumentCounts {
+  [documentType: string]: number
+}
+
+/**
+ * Account Deletion Service
+ *
+ * Handles comprehensive deletion of all user documents across all Yappr contracts.
+ * Uses a registry-based architecture for easy extensibility when new document types are added.
+ */
+class AccountDeletionService {
+  /**
+   * Registry of all contracts and document types that should be deleted.
+   *
+   * IMPORTANT: When adding new document types to Yappr, add them here to ensure
+   * they are deleted during account deletion.
+   */
+  private readonly registry: DeletionRegistry[] = [
+    // Main Yappr contract - social features
+    {
+      contractId: YAPPR_CONTRACT_ID,
+      documentTypes: [
+        'post',           // User's posts
+        'like',           // User's likes
+        'repost',         // User's reposts
+        'follow',         // Users this user follows
+        'bookmark',       // User's bookmarks
+        'list',           // User's custom lists
+        'listMember',     // Members in user's lists
+        'notification',   // User's notifications
+        'profile',        // User's profile (old contract)
+        'avatar',         // User's avatar
+      ],
+      serviceName: 'Main Social'
+    },
+    // Unified profile contract
+    {
+      contractId: YAPPR_PROFILE_CONTRACT_ID,
+      documentTypes: ['profile'],
+      serviceName: 'Profile'
+    },
+    // Direct messages contract
+    {
+      contractId: YAPPR_DM_CONTRACT_ID,
+      documentTypes: ['directMessage'],
+      serviceName: 'Direct Messages'
+    },
+    // Block/mute contract
+    {
+      contractId: YAPPR_BLOCK_CONTRACT_ID,
+      documentTypes: [
+        'block',          // Blocked users
+        'blockFilter',    // Bloom filter for blocks
+        'blockFollow',    // Block follows
+        'mute',           // Muted users
+      ],
+      serviceName: 'Block System'
+    },
+    // Encrypted key backup contract
+    {
+      contractId: ENCRYPTED_KEY_BACKUP_CONTRACT_ID,
+      documentTypes: ['encryptedKeyBackup'],
+      serviceName: 'Key Backup'
+    },
+    // Hashtag tracking contract
+    {
+      contractId: HASHTAG_CONTRACT_ID,
+      documentTypes: ['postHashtag'],
+      serviceName: 'Hashtags'
+    }
+  ]
+
+  /**
+   * Batch size for concurrent deletions within a document type
+   */
+  private readonly BATCH_SIZE = 3
+
+  /**
+   * Delay between batches to avoid rate limiting (ms)
+   */
+  private readonly BATCH_DELAY_MS = 500
+
+  /**
+   * Maximum documents to query per request (Platform limit)
+   */
+  private readonly QUERY_LIMIT = 100
+
+  /**
+   * Count all user documents across all contracts
+   */
+  async countUserDocuments(userId: string): Promise<DocumentCounts> {
+    const counts: DocumentCounts = {}
+
+    for (const entry of this.registry) {
+      for (const documentType of entry.documentTypes) {
+        try {
+          const documents = await this.queryUserDocuments(
+            entry.contractId,
+            documentType,
+            userId
+          )
+          if (documents.length > 0) {
+            counts[documentType] = documents.length
+          }
+        } catch (error) {
+          // Log but continue - some document types may not exist for this user
+          console.warn(`Failed to count ${documentType}:`, error)
+        }
+      }
+    }
+
+    return counts
+  }
+
+  /**
+   * Query all documents owned by a user for a specific type
+   * Handles pagination for users with many documents
+   */
+  private async queryUserDocuments(
+    contractId: string,
+    documentType: string,
+    userId: string
+  ): Promise<DocumentInfo[]> {
+    const sdk = await getEvoSdk()
+    const allDocuments: DocumentInfo[] = []
+    let startAfter: string | undefined = undefined
+
+    // Paginate through all documents
+    while (true) {
+      try {
+        const queryOptions = {
+          dataContractId: contractId,
+          documentTypeName: documentType,
+          where: [['$ownerId', '==', userId]],
+          orderBy: [['$createdAt', 'asc']],
+          limit: this.QUERY_LIMIT,
+          ...(startAfter && { startAfter })
+        }
+
+        const response = await sdk.documents.query(queryOptions as any)
+
+        // Handle both array and Map responses
+        let documents: any[] = []
+        if (response instanceof Map) {
+          documents = Array.from(response.values())
+        } else if (Array.isArray(response)) {
+          documents = response
+        } else if (response && typeof response === 'object') {
+          documents = Object.values(response)
+        }
+
+        if (documents.length === 0) {
+          break
+        }
+
+        // Add documents with metadata
+        for (const doc of documents) {
+          allDocuments.push({
+            $id: doc.$id || doc.id,
+            $ownerId: doc.$ownerId || doc.ownerId || userId,
+            documentType,
+            contractId
+          })
+        }
+
+        // Check if we need to paginate
+        if (documents.length < this.QUERY_LIMIT) {
+          break
+        }
+
+        // Use last document ID for pagination
+        const lastDoc = documents[documents.length - 1]
+        startAfter = lastDoc.$id || lastDoc.id
+      } catch (error) {
+        // Some document types may fail to query (e.g., not registered)
+        console.warn(`Query failed for ${documentType} in contract ${contractId}:`, error)
+        break
+      }
+    }
+
+    return allDocuments
+  }
+
+  /**
+   * Delete all user documents with progress callback
+   */
+  async deleteAllUserDocuments(
+    userId: string,
+    onProgress: (progress: DeletionProgress) => void
+  ): Promise<DeletionResult> {
+    const progress: DeletionProgress = {
+      phase: 'counting',
+      currentContract: '',
+      currentDocumentType: '',
+      totalDocuments: 0,
+      processedDocuments: 0,
+      deletedDocuments: 0,
+      failedDocuments: 0,
+      errors: []
+    }
+
+    // First, collect all documents to delete
+    const allDocuments: DocumentInfo[] = []
+
+    for (const entry of this.registry) {
+      progress.currentContract = entry.serviceName
+
+      for (const documentType of entry.documentTypes) {
+        progress.currentDocumentType = documentType
+        onProgress({ ...progress })
+
+        try {
+          const documents = await this.queryUserDocuments(
+            entry.contractId,
+            documentType,
+            userId
+          )
+          allDocuments.push(...documents)
+          progress.totalDocuments = allDocuments.length
+          onProgress({ ...progress })
+        } catch (error) {
+          console.warn(`Failed to query ${documentType}:`, error)
+        }
+      }
+    }
+
+    // Now delete all documents
+    progress.phase = 'deleting'
+    onProgress({ ...progress })
+
+    // Process deletions in batches
+    for (let i = 0; i < allDocuments.length; i += this.BATCH_SIZE) {
+      const batch = allDocuments.slice(i, i + this.BATCH_SIZE)
+
+      // Update progress with current document type being processed
+      if (batch.length > 0) {
+        progress.currentDocumentType = batch[0].documentType
+        progress.currentContract = this.getServiceName(batch[0].contractId)
+      }
+      onProgress({ ...progress })
+
+      // Process batch concurrently
+      const results = await Promise.allSettled(
+        batch.map(doc => this.deleteDocument(doc))
+      )
+
+      // Update progress based on results
+      for (let j = 0; j < results.length; j++) {
+        progress.processedDocuments++
+        const result = results[j]
+
+        if (result.status === 'fulfilled' && result.value.success) {
+          progress.deletedDocuments++
+        } else {
+          progress.failedDocuments++
+          progress.errors.push({
+            contractId: batch[j].contractId,
+            documentType: batch[j].documentType,
+            documentId: batch[j].$id,
+            error: result.status === 'rejected'
+              ? result.reason?.message || 'Unknown error'
+              : (result.value as { error?: string }).error || 'Delete failed'
+          })
+        }
+
+        onProgress({ ...progress })
+      }
+
+      // Add delay between batches to avoid rate limiting
+      if (i + this.BATCH_SIZE < allDocuments.length) {
+        await this.delay(this.BATCH_DELAY_MS)
+      }
+    }
+
+    // Determine final status
+    const totalFailed = progress.failedDocuments
+    const totalDeleted = progress.deletedDocuments
+
+    progress.phase = totalFailed === 0 ? 'complete' : 'failed'
+    onProgress({ ...progress })
+
+    return {
+      success: totalFailed === 0,
+      totalDeleted,
+      totalFailed,
+      errors: progress.errors,
+      partialFailure: totalFailed > 0 && totalDeleted > 0
+    }
+  }
+
+  /**
+   * Delete a single document
+   */
+  private async deleteDocument(doc: DocumentInfo): Promise<{ success: boolean; error?: string }> {
+    try {
+      const result = await stateTransitionService.deleteDocument(
+        doc.contractId,
+        doc.documentType,
+        doc.$id,
+        doc.$ownerId
+      )
+      return { success: result.success, error: result.error }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  }
+
+  /**
+   * Clear all local storage related to the user session
+   */
+  async clearLocalStorage(userId: string): Promise<void> {
+    // Clear session storage items
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('yappr_session')
+      sessionStorage.removeItem('yappr_dpns_username')
+      sessionStorage.removeItem('yappr_skip_dpns')
+      sessionStorage.removeItem('yappr_backup_prompt_shown')
+
+      // Clear private key from secure storage
+      const { clearPrivateKey } = await import('../secure-storage')
+      clearPrivateKey(userId)
+
+      // Clear block cache
+      const { invalidateBlockCache } = await import('../caches/block-cache')
+      invalidateBlockCache(userId)
+
+      // Clear DashPlatformClient identity
+      const { getDashPlatformClient } = await import('../dash-platform-client')
+      const dashClient = getDashPlatformClient()
+      dashClient.setIdentity('')
+    }
+  }
+
+  /**
+   * Full account deletion orchestration
+   */
+  async deleteAccount(
+    userId: string,
+    onProgress: (progress: DeletionProgress) => void
+  ): Promise<DeletionResult> {
+    // Delete all documents
+    const result = await this.deleteAllUserDocuments(userId, onProgress)
+
+    // If deletion was successful or partially successful, clear local storage
+    if (result.totalDeleted > 0 || result.totalFailed === 0) {
+      const progress: DeletionProgress = {
+        phase: 'cleanup',
+        currentContract: '',
+        currentDocumentType: 'Local Storage',
+        totalDocuments: result.totalDeleted + result.totalFailed,
+        processedDocuments: result.totalDeleted + result.totalFailed,
+        deletedDocuments: result.totalDeleted,
+        failedDocuments: result.totalFailed,
+        errors: result.errors
+      }
+      onProgress(progress)
+
+      await this.clearLocalStorage(userId)
+    }
+
+    return result
+  }
+
+  /**
+   * Get service name for a contract ID
+   */
+  private getServiceName(contractId: string): string {
+    const entry = this.registry.find(e => e.contractId === contractId)
+    return entry?.serviceName || 'Unknown'
+  }
+
+  /**
+   * Helper to delay execution
+   */
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+
+  /**
+   * Get all document types that will be deleted
+   * Useful for displaying to the user what will be affected
+   */
+  getAffectedDocumentTypes(): string[] {
+    const types: string[] = []
+    for (const entry of this.registry) {
+      types.push(...entry.documentTypes)
+    }
+    return Array.from(new Set(types)) // Remove duplicates
+  }
+
+  /**
+   * Get human-readable descriptions of what will be deleted
+   */
+  getDeletionSummary(): Array<{ category: string; items: string[] }> {
+    return [
+      {
+        category: 'Social Content',
+        items: ['All your posts', 'All your replies', 'All your reposts/quotes']
+      },
+      {
+        category: 'Interactions',
+        items: ['All your likes', 'All your bookmarks', 'All users you follow']
+      },
+      {
+        category: 'Profile Data',
+        items: ['Your profile information', 'Your avatar', 'Your display name and bio']
+      },
+      {
+        category: 'Private Data',
+        items: ['All your direct messages', 'Your block and mute lists']
+      },
+      {
+        category: 'Other Data',
+        items: ['Your custom lists', 'Notification history', 'Encrypted key backups']
+      }
+    ]
+  }
+}
+
+// Export singleton instance
+export const accountDeletionService = new AccountDeletionService()

--- a/lib/services/account-deletion-service.ts
+++ b/lib/services/account-deletion-service.ts
@@ -1,6 +1,6 @@
 import { getEvoSdk } from './evo-sdk-service'
-import { queryDocuments, identifierToBase58 } from './sdk-helpers'
 import { stateTransitionService } from './state-transition-service'
+import { queryDocuments, identifierToBase58 } from './sdk-helpers'
 import {
   YAPPR_CONTRACT_ID,
   YAPPR_PROFILE_CONTRACT_ID,
@@ -179,6 +179,7 @@ class AccountDeletionService {
   /**
    * Query all documents owned by a user for a specific type
    * Handles pagination for users with many documents
+   * Uses queryDocuments from sdk-helpers for proper error handling
    */
   private async queryUserDocuments(
     contractId: string,


### PR DESCRIPTION
- Add registry-based AccountDeletionService that deletes all user documents across all Yappr contracts (main, profile, DM, block, hashtag, key backup)
- Create multi-step delete account modal with warning, confirmation (type DELETE), progress tracking, and completion/error states
- Add clear warnings about third-party indexers retaining historical copies
- Update privacy policy to reflect that deletion IS now possible from Dash Platform, with caveats about external services
- Clean up local storage after successful deletion

The service uses a future-proof registry pattern - new document types just need to be added to the registry array to be included in deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step account deletion modal with typed confirmation, progress bar, per-item progress, and completion/error screens.
* **Documentation**
  * Privacy page updated to explain data deletion, lists items removed (posts, likes, replies, profile, follows, DMs, etc.), and warns third parties may retain copies.
* **Chores**
  * Private keys now stored via a secure storage flow during creation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->