### PR TITLE
Fix DPNS normalization to only remove trailing .dash suffix

### DIFF
--- a/lib/services/dpns-service.ts
+++ b/lib/services/dpns-service.ts
@@ -300,7 +300,7 @@ class DpnsService {
    */
   async isUsernameAvailable(username: string): Promise<boolean> {
     try {
-      const normalizedUsername = username.toLowerCase().replace('.dash', '');
+      const normalizedUsername = username.toLowerCase().replace(/\.dash$/, '');
 
       // Try native availability check first (more efficient)
       try {


### PR DESCRIPTION
Changed from .replace('.dash', '') to .replace(/\.dash$/, '') to ensure only a trailing ".dash" is removed, not mid-string occurrences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed username normalization logic to properly handle usernames containing embedded ".dash" substrings by only removing trailing suffixes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->