### PR TITLE
Add Ctrl+Enter keyboard shortcut to post submission

### DIFF
--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -146,6 +146,12 @@ function PostDetailContent() {
                     placeholder="Post your reply"
                     value={replyContent}
                     onChange={(e) => setReplyContent(e.target.value)}
+                    onKeyDown={(e) => {
+                      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                        e.preventDefault()
+                        handleReply()
+                      }
+                    }}
                     className="w-full"
                     maxLength={500}
                   />

--- a/components/compose/compose-modal.tsx
+++ b/components/compose/compose-modal.tsx
@@ -205,6 +205,12 @@ export function ComposeModal() {
                         ref={textareaRef}
                         value={content}
                         onChange={(e) => setContent(e.target.value)}
+                        onKeyDown={(e) => {
+                          if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                            e.preventDefault()
+                            handlePost()
+                          }
+                        }}
                         placeholder={replyingTo ? "Post your reply" : quotingPost ? "Add your comment" : "What's happening?"}
                         className="w-full min-h-[120px] text-lg resize-none outline-none bg-transparent placeholder:text-gray-500"
                       />


### PR DESCRIPTION
Adds keyboard shortcut (Ctrl+Enter or Cmd+Enter on Mac) to submit posts:
- Compose modal textarea for creating new posts, replies, and quotes
- Inline reply input on post detail page