### PR TITLE
Fix auto-focus on compose modal textarea

### DIFF
--- a/components/compose/compose-modal.tsx
+++ b/components/compose/compose-modal.tsx
@@ -30,8 +30,12 @@ export function ComposeModal() {
   const progressPercentage = (content.length / characterLimit) * 100
 
   useEffect(() => {
-    if (isComposeOpen && textareaRef.current) {
-      textareaRef.current.focus()
+    if (isComposeOpen) {
+      // Small delay to ensure the modal animation has mounted the textarea
+      const timeoutId = setTimeout(() => {
+        textareaRef.current?.focus()
+      }, 50)
+      return () => clearTimeout(timeoutId)
     }
   }, [isComposeOpen])
 


### PR DESCRIPTION
Add small delay before focusing to ensure the modal animation has mounted the textarea in the DOM. Without this delay, focus was being called before the element was rendered.