### PR TITLE
Fix bloom filter bitwise operation producing negative values

### DIFF
--- a/lib/bloom-filter.ts
+++ b/lib/bloom-filter.ts
@@ -92,10 +92,13 @@ export class BloomFilter {
 
       const offset = (i % 8) * 4
       // Read 4 bytes as big-endian unsigned integer
-      const value = ((hash[offset] << 24) >>> 0) |
-                    (hash[offset + 1] << 16) |
-                    (hash[offset + 2] << 8) |
-                    hash[offset + 3]
+      // Note: >>> 0 must be applied to the entire expression, not just the first shift,
+      // because JavaScript's bitwise OR operates on signed 32-bit integers and can
+      // produce negative results if the high bit is set.
+      const value = (((hash[offset] << 24) |
+                      (hash[offset + 1] << 16) |
+                      (hash[offset + 2] << 8) |
+                      hash[offset + 3]) >>> 0)
 
       // Modulo to get position within filter
       positions.push(value % FILTER_SIZE_BITS)


### PR DESCRIPTION
## Summary
- Fix critical bug in bloom filter hash position calculation where JavaScript's bitwise OR produced negative values when high bits were set
- The `>>> 0` operator was only applied to the first shift, but needed to be applied to the entire expression

## Problem
When hash bytes had high bits set (e.g., 0xFF), the calculation:
```javascript
const value = ((hash[offset] << 24) >>> 0) |
              (hash[offset + 1] << 16) |
              (hash[offset + 2] << 8) |
              hash[offset + 3]
```

Would produce negative values because JavaScript's `|` operator works on signed 32-bit integers. For example, with bytes `[0xFF, 0xFF, 0xFF, 0xFF]`, the result was `-1` instead of `4294967295`.

This caused:
- Negative array indices when setting/checking bits
- Incorrect modulo results (`-1 % 40000 = -1`)
- Bits not being set at correct positions
- **False negatives** in block checking (blocked users appearing unblocked)

## Fix
Apply `>>> 0` to the entire expression:
```javascript
const value = (((hash[offset] << 24) |
                (hash[offset + 1] << 16) |
                (hash[offset + 2] << 8) |
                hash[offset + 3]) >>> 0)
```

## Test plan
- [x] Verified fix produces correct unsigned values with test script
- [x] Build passes with no TypeScript errors
- [ ] Test blocking functionality in app

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue in Bloom filter calculations that could produce incorrect results when certain values were set, ensuring accurate filtering operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->