### PR TITLE
Show loading skeleton instead of 'User XKSFJL' placeholder while load…

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -83,10 +83,19 @@ export default function ExplorePage() {
             content: post.content,
             author: {
               id: post.$ownerId,
-              username: post.$ownerId.slice(0, 8) + '...',
-              handle: post.$ownerId.slice(0, 8).toLowerCase()
+              // Leave empty for PostCard skeleton - will be enriched progressively
+              username: '',
+              handle: '',
+              displayName: '',
+              avatar: '',
+              followers: 0,
+              following: 0,
+              verified: false,
+              joinedAt: new Date(),
+              // undefined = still loading, will show skeleton in PostCard
+              hasDpns: undefined
             },
-            timestamp: new Date(post.$createdAt || 0).toISOString(),
+            createdAt: new Date(post.$createdAt || 0),
             likes: 0,
             replies: 0,
             reposts: 0,

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -177,13 +177,15 @@ function UserProfileContent() {
               id: authorIdStr,
               // Don't use a fake username format - leave empty and let hasDpns control display
               username: '',
-              displayName: profileDisplayName,
+              // Use empty displayName initially - skeleton shows when hasDpns is undefined
+              displayName: '',
               avatar: '', // Let UserAvatar fetch the actual avatar
               verified: false,
               followers: 0,
               following: 0,
               joinedAt: new Date(),
-              hasDpns: false, // Set to false initially, will update if DPNS found
+              // undefined = still loading, will show skeleton in PostCard
+              hasDpns: undefined,
             } as any,
             createdAt: new Date(doc.$createdAt || doc.createdAt || Date.now()),
             likes: 0,
@@ -363,8 +365,10 @@ function UserProfileContent() {
             content: doc.content || '',
             author: {
               id: authorIdStr,
-              username: username || `user_${authorIdStr.slice(-6)}`,
-              displayName: profile?.displayName || `User ${authorIdStr.slice(-6)}`,
+              // Use resolved username or empty string (not fake user_ prefix)
+              username: username || '',
+              // Use resolved displayName or empty string for skeleton/enrichment
+              displayName: profile?.displayName || '',
               avatar: '',
               verified: false,
               followers: 0,
@@ -412,7 +416,8 @@ function UserProfileContent() {
                   ...originalPost,
                   repostedBy: {
                     id: userId,
-                    displayName: profile?.displayName || `User ${userId.slice(-6)}`,
+                    // Empty string shows "Someone reposted" instead of "User XKSFJL reposted"
+                    displayName: profile?.displayName || '',
                     username: reposterUsername
                   },
                   repostTimestamp: new Date(repost.$createdAt)


### PR DESCRIPTION
…ing usernames

When posts load, they briefly showed 'User XKSFJL' (truncated identity ID) before the actual display name was fetched. This was jarring UX because it looked like a broken username.

Fix: Set hasDpns to undefined (indicating 'loading') instead of false (indicating 'no DPNS found') when initially creating post objects. PostCard already has skeleton rendering logic for when hasDpns is undefined.

Changes:
- feed/page.tsx: Use hasDpns: undefined and empty displayName for For You and Following feeds while loading. Reposts now show "Someone reposted" instead of "User XKSFJL reposted" when profile isn't available.
- user/page.tsx: Same pattern for user profile posts - show skeleton until DPNS/profile data loads.
- explore/page.tsx: Search results now use proper author structure with hasDpns: undefined for consistent skeleton display.