### PR TITLE
Fix username and avatar loading states

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -634,11 +634,19 @@ function UserProfileContent() {
         </header>
 
         {isLoading ? (
-          <div className="p-8">
-            <div className="h-48 bg-gray-100 dark:bg-gray-900 animate-pulse" />
+          <div>
+            <div className="h-48 bg-gradient-yappr opacity-50" />
             <div className="px-4 pb-4">
               <div className="relative -mt-16 mb-4">
-                <div className="h-32 w-32 rounded-full bg-gray-200 dark:bg-gray-800 animate-pulse" />
+                <div className="h-32 w-32 rounded-full bg-white dark:bg-neutral-900 p-1">
+                  <div className="h-full w-full rounded-full overflow-hidden blur-sm opacity-60">
+                    <UserAvatar
+                      userId={userId || 'default'}
+                      alt="Loading..."
+                      size="full"
+                    />
+                  </div>
+                </div>
               </div>
               <div className="h-6 w-48 bg-gray-200 dark:bg-gray-800 rounded animate-pulse mb-2" />
               <div className="h-4 w-32 bg-gray-200 dark:bg-gray-800 rounded animate-pulse" />
@@ -1129,11 +1137,13 @@ function LoadingFallback() {
       <Sidebar />
       <div className="flex-1 flex justify-center min-w-0">
         <main className="w-full max-w-[700px] md:border-x border-gray-200 dark:border-gray-800">
-          <div className="p-8">
-            <div className="h-48 bg-gray-100 dark:bg-gray-900 animate-pulse" />
+          <div>
+            <div className="h-48 bg-gradient-yappr opacity-50" />
             <div className="px-4 pb-4">
               <div className="relative -mt-16 mb-4">
-                <div className="h-32 w-32 rounded-full bg-gray-200 dark:bg-gray-800 animate-pulse" />
+                <div className="h-32 w-32 rounded-full bg-white dark:bg-neutral-900 p-1">
+                  <div className="h-full w-full rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse" />
+                </div>
               </div>
               <div className="h-6 w-48 bg-gray-200 dark:bg-gray-800 rounded animate-pulse mb-2" />
               <div className="h-4 w-32 bg-gray-200 dark:bg-gray-800 rounded animate-pulse" />

--- a/components/post/post-card.tsx
+++ b/components/post/post-card.tsx
@@ -403,7 +403,7 @@ export function PostCard({ post, hideAvatar = false, isOwnPost: isOwnPostProp, e
             <div className="flex items-center gap-1 text-sm min-w-0">
               {!hideAvatar && (
                 <>
-                  {usernameState === undefined ? (
+                  {usernameState === undefined || (displayName === 'Unknown User' || displayName?.startsWith('User ')) ? (
                     // Still loading - show skeleton for display name
                     <span className="inline-block w-24 h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
                   ) : (
@@ -429,8 +429,11 @@ export function PostCard({ post, hideAvatar = false, isOwnPost: isOwnPostProp, e
                     >
                       @{usernameState}
                     </Link>
-                  ) : usernameState === null && !hasProfile ? (
-                    // No DPNS and no profile - show identity ID
+                  ) : usernameState === undefined || (displayName === 'Unknown User' || displayName?.startsWith('User ')) ? (
+                    // Still loading DPNS OR profile data - show skeleton
+                    <span className="inline-block w-20 h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+                  ) : !hasProfile ? (
+                    // No DPNS and no profile after enrichment - show identity ID
                     <Tooltip.Provider>
                       <Tooltip.Root>
                         <Tooltip.Trigger asChild>
@@ -455,9 +458,6 @@ export function PostCard({ post, hideAvatar = false, isOwnPost: isOwnPostProp, e
                         </Tooltip.Portal>
                       </Tooltip.Root>
                     </Tooltip.Provider>
-                  ) : usernameState === undefined ? (
-                    // Still loading - show skeleton
-                    <span className="inline-block w-20 h-4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
                   ) : null /* Has profile but no DPNS - display name is sufficient */}
                 </>
               )}


### PR DESCRIPTION
- Post page: Show skeleton for displayName/username when profile data is still loading (displayName is 'Unknown User' or 'User ...' placeholder) instead of briefly flashing those placeholders
- User page: Show blurred avatar with gradient banner during loading instead of generic gray skeleton, providing better visual continuity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced user profile loading UI with more sophisticated visual placeholders and skeleton screens.
  * Improved detection and display of loading states in post cards for better user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->