### PR TITLE
Show login prompt when non-authenticated user visits Following tab

### DIFF
--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -17,6 +17,7 @@ import { withAuth, useAuth } from '@/contexts/auth-context'
 import { UserAvatar } from '@/components/ui/avatar-image'
 import { LoadingState, useAsyncState } from '@/components/ui/loading-state'
 import ErrorBoundary from '@/components/error-boundary'
+import { useLoginPromptModal } from '@/hooks/use-login-prompt-modal'
 import { getDashPlatformClient } from '@/lib/dash-platform-client'
 import { cacheManager } from '@/lib/cache-manager'
 import { useProgressiveEnrichment } from '@/hooks/use-progressive-enrichment'
@@ -29,6 +30,7 @@ function FeedPage() {
   const [isHydrated, setIsHydrated] = useState(false)
   const { setComposeOpen } = useAppStore()
   const { user } = useAuth()
+  const { open: openLoginPrompt } = useLoginPromptModal()
   const postsState = useAsyncState<any[]>(null)
   const [migrationStatus, setMigrationStatus] = useState<MigrationStatus>('no_profile')
   const [hasMore, setHasMore] = useState(true)
@@ -771,6 +773,28 @@ function FeedPage() {
           </div>
         )}
 
+        {/* Login prompt for non-authenticated users on Following tab */}
+        {activeTab === 'following' && !user ? (
+          <div className="flex flex-col items-center justify-center py-16 px-4">
+            <div className="w-16 h-16 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+              </svg>
+            </div>
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+              See posts from people you follow
+            </h3>
+            <p className="text-gray-500 dark:text-gray-400 text-center max-w-sm mb-6">
+              Log in to view your personalized following feed and see updates from accounts you care about.
+            </p>
+            <Button
+              onClick={() => openLoginPrompt('view_following')}
+              className="px-6"
+            >
+              Log in
+            </Button>
+          </div>
+        ) : (
         <ErrorBoundary level="component">
           <LoadingState
             loading={postsState.loading || postsState.data === null}
@@ -825,6 +849,7 @@ function FeedPage() {
             </div>
           </LoadingState>
         </ErrorBoundary>
+        )}
         </main>
       </div>
 

--- a/hooks/use-login-prompt-modal.ts
+++ b/hooks/use-login-prompt-modal.ts
@@ -13,6 +13,7 @@ export type LoginPromptAction =
   | 'follow'
   | 'block'
   | 'message'
+  | 'view_following'
   | 'generic'
 
 interface LoginPromptModalStore {
@@ -59,6 +60,8 @@ export function getActionDescription(action: LoginPromptAction): string {
       return 'block users'
     case 'message':
       return 'send messages'
+    case 'view_following':
+      return 'see posts from people you follow'
     case 'generic':
     default:
       return 'perform this action'


### PR DESCRIPTION
When a logged-out user navigates to the Following tab on the feed page, they now see a friendly message explaining they need to log in to see posts from people they follow, along with a login button that opens the login prompt modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added login prompts on the Following tab to encourage non-authenticated users to log in. The prompt appears in multiple locations and invites users to view posts from accounts they follow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->