### PR TITLE
Fix reply icon not working on hashtag, explore, bookmarks, and user p…

### DIFF
--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -13,6 +13,7 @@ import { BookmarkIcon as BookmarkIconSolid } from '@heroicons/react/24/solid'
 import { Sidebar } from '@/components/layout/sidebar'
 import { RightSidebar } from '@/components/layout/right-sidebar'
 import { PostCard } from '@/components/post/post-card'
+import { ComposeModal } from '@/components/compose/compose-modal'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { withAuth, useAuth } from '@/contexts/auth-context'
@@ -288,6 +289,7 @@ function BookmarksPage() {
       </div>
 
       <RightSidebar />
+      <ComposeModal />
     </div>
   )
 }

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -6,6 +6,7 @@ import { MagnifyingGlassIcon, ArrowLeftIcon, HashtagIcon, FireIcon } from '@hero
 import { Sidebar } from '@/components/layout/sidebar'
 import { RightSidebar } from '@/components/layout/right-sidebar'
 import { PostCard } from '@/components/post/post-card'
+import { ComposeModal } from '@/components/compose/compose-modal'
 import { formatNumber } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
 import { hashtagService, TrendingHashtag } from '@/lib/services/hashtag-service'
@@ -242,6 +243,7 @@ export default function ExplorePage() {
       </div>
 
       <RightSidebar />
+      <ComposeModal />
     </div>
   )
 }

--- a/app/hashtag/page.tsx
+++ b/app/hashtag/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeftIcon, HashtagIcon, CurrencyDollarIcon } from '@heroicons/react
 import { Sidebar } from '@/components/layout/sidebar'
 import { RightSidebar } from '@/components/layout/right-sidebar'
 import { PostCard } from '@/components/post/post-card'
+import { ComposeModal } from '@/components/compose/compose-modal'
 import { formatNumber } from '@/lib/utils'
 import { hashtagService } from '@/lib/services/hashtag-service'
 import { HASHTAG_CONTRACT_ID } from '@/lib/constants'
@@ -191,6 +192,7 @@ function HashtagPageContent() {
       </div>
 
       <RightSidebar />
+      <ComposeModal />
     </div>
   )
 }

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -21,6 +21,7 @@ import { Sidebar } from '@/components/layout/sidebar'
 import { RightSidebar } from '@/components/layout/right-sidebar'
 import { Button } from '@/components/ui/button'
 import { PostCard } from '@/components/post/post-card'
+import { ComposeModal } from '@/components/compose/compose-modal'
 import { formatNumber } from '@/lib/utils'
 import { UserAvatar, invalidateAvatarImageCache } from '@/components/ui/avatar-image'
 import { AvatarCustomization } from '@/components/settings/avatar-customization'
@@ -1085,6 +1086,7 @@ function UserProfileContent() {
       </div>
 
       <RightSidebar />
+      <ComposeModal />
 
       {/* Avatar Customization Modal */}
       {isEditingAvatar && (


### PR DESCRIPTION
…ages

The ComposeModal component was only rendered on the feed and post detail pages. When clicking the reply icon on other pages, handleReply() would call setComposeOpen(true), but there was no ComposeModal component listening to display the modal.

Added ComposeModal to:
- app/hashtag/page.tsx
- app/explore/page.tsx
- app/bookmarks/page.tsx
- app/user/page.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compose modal now available on Bookmarks, Explore, Hashtag, and Profile pages for quicker content creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->