### PR TITLE
Add bold, italic, and code formatting to post content rendering

### DIFF
--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -25,6 +25,8 @@ type PartType = 'text' | 'hashtag' | 'cashtag' | 'mention' | 'url' | 'bold' | 'i
 interface ContentPart {
   type: PartType
   value: string
+  // For bold/italic, children contains parsed inner content (hashtags, mentions, etc.)
+  children?: ContentPart[]
 }
 
 /**
@@ -47,15 +49,8 @@ export function PostContent({
     { disabled: disableLinkPreview, richPreview: richLinkPreviews }
   )
   const parsedContent = useMemo(() => {
-    // Pattern definitions with their types
-    // Order matters: more specific patterns first to avoid incorrect matches
-    const patterns: Array<{ regex: RegExp; type: PartType }> = [
-      // Bold: **text** (must come before italic)
-      { regex: /\*\*([^*]+)\*\*/g, type: 'bold' },
-      // Italic: *text* (but not **)
-      { regex: /(?<!\*)\*([^*]+)\*(?!\*)/g, type: 'italic' },
-      // Code: `text`
-      { regex: /`([^`]+)`/g, type: 'code' },
+    // Patterns for inline elements (hashtags, cashtags, mentions, urls)
+    const inlinePatterns: Array<{ regex: RegExp; type: PartType }> = [
       // URLs: http://, https://, or www. prefixed
       { regex: /(https?:\/\/[^\s<>\"\']+|www\.[^\s<>\"\']+)/g, type: 'url' },
       // Hashtags: # followed by alphanumeric/underscore (1-63 chars)
@@ -64,6 +59,71 @@ export function PostContent({
       { regex: /\$([a-zA-Z][a-zA-Z0-9_]{0,62})/g, type: 'cashtag' },
       // Mentions: @ followed by alphanumeric/underscore (1-100 chars)
       { regex: /@([a-zA-Z0-9_]{1,100})/g, type: 'mention' },
+    ]
+
+    // Parse text for inline elements only (used for inner content of bold/italic)
+    function parseInlineContent(text: string): ContentPart[] {
+      interface Match {
+        type: PartType
+        start: number
+        end: number
+        fullMatch: string
+      }
+
+      const allMatches: Match[] = []
+
+      for (const { regex, type } of inlinePatterns) {
+        let match
+        const re = new RegExp(regex.source, regex.flags)
+        while ((match = re.exec(text)) !== null) {
+          allMatches.push({
+            type,
+            start: match.index,
+            end: match.index + match[0].length,
+            fullMatch: match[0],
+          })
+        }
+      }
+
+      // Sort by position and remove overlaps
+      allMatches.sort((a, b) => a.start - b.start)
+      const filteredMatches: Match[] = []
+      let lastEnd = 0
+      for (const match of allMatches) {
+        if (match.start >= lastEnd) {
+          filteredMatches.push(match)
+          lastEnd = match.end
+        }
+      }
+
+      // Build parts
+      const parts: ContentPart[] = []
+      let currentIndex = 0
+
+      for (const match of filteredMatches) {
+        if (match.start > currentIndex) {
+          parts.push({ type: 'text', value: text.slice(currentIndex, match.start) })
+        }
+        parts.push({ type: match.type, value: match.fullMatch })
+        currentIndex = match.end
+      }
+
+      if (currentIndex < text.length) {
+        parts.push({ type: 'text', value: text.slice(currentIndex) })
+      }
+
+      return parts
+    }
+
+    // All patterns including formatting
+    const allPatterns: Array<{ regex: RegExp; type: PartType }> = [
+      // Bold: **text** (must come before italic)
+      { regex: /\*\*([^*]+)\*\*/g, type: 'bold' },
+      // Italic: *text* (but not **)
+      { regex: /(?<!\*)\*([^*]+)\*(?!\*)/g, type: 'italic' },
+      // Code: `text`
+      { regex: /`([^`]+)`/g, type: 'code' },
+      ...inlinePatterns,
     ]
 
     // Find all matches with their positions
@@ -77,7 +137,7 @@ export function PostContent({
 
     const allMatches: Match[] = []
 
-    for (const { regex, type } of patterns) {
+    for (const { regex, type } of allPatterns) {
       let match
       const re = new RegExp(regex.source, regex.flags)
       while ((match = re.exec(content)) !== null) {
@@ -118,10 +178,13 @@ export function PostContent({
       }
 
       // Add the matched part
-      // For formatting (bold/italic/code), store the inner content
-      // For links/tags, store the full match (including prefix)
-      if (match.type === 'bold' || match.type === 'italic' || match.type === 'code') {
-        parts.push({ type: match.type, value: match.innerContent })
+      if (match.type === 'bold' || match.type === 'italic') {
+        // For bold/italic, recursively parse inner content for hashtags, mentions, etc.
+        const children = parseInlineContent(match.innerContent)
+        parts.push({ type: match.type, value: match.innerContent, children })
+      } else if (match.type === 'code') {
+        // Code blocks are literal - no nested parsing
+        parts.push({ type: 'code', value: match.innerContent })
       } else if (match.type === 'url') {
         parts.push({ type: 'url', value: match.fullMatch })
       } else {
@@ -140,6 +203,113 @@ export function PostContent({
     return parts
   }, [content])
 
+  // Helper to render a single inline part (hashtag, cashtag, mention, url, text)
+  // Used for both top-level and nested content inside bold/italic
+  const renderInlinePart = (part: ContentPart, key: string | number): React.ReactNode => {
+    if (part.type === 'url') {
+      const href = part.value.startsWith('www.')
+        ? `https://${part.value}`
+        : part.value
+      const cleanHref = href.replace(/[.,;:!?)]+$/, '')
+      const cleanDisplay = part.value.replace(/[.,;:!?)]+$/, '')
+      const trailingPunctuation = part.value.slice(cleanDisplay.length)
+
+      return (
+        <Fragment key={key}>
+          <a
+            href={cleanHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-yappr-500 hover:underline break-all"
+          >
+            {cleanDisplay}
+          </a>
+          {trailingPunctuation}
+        </Fragment>
+      )
+    }
+
+    if (part.type === 'hashtag') {
+      const tag = part.value.slice(1).toLowerCase()
+      const validationStatus = hashtagValidations?.get(tag)
+      const isFailed = validationStatus === 'invalid'
+
+      return (
+        <span key={key} className="inline-flex items-center">
+          <Link
+            href={`/hashtag?tag=${encodeURIComponent(tag)}`}
+            onClick={(e) => e.stopPropagation()}
+            className={`text-yappr-500 hover:underline ${isFailed ? 'opacity-70' : ''}`}
+          >
+            {part.value}
+          </Link>
+          {isFailed && onFailedHashtagClick && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                onFailedHashtagClick(tag)
+              }}
+              className="ml-0.5 text-amber-500 hover:text-amber-600 transition-colors"
+              title="Hashtag not registered - click to fix"
+            >
+              <ExclamationTriangleIcon className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </span>
+      )
+    }
+
+    if (part.type === 'cashtag') {
+      const storageTag = cashtagDisplayToStorage(part.value)
+      const validationStatus = hashtagValidations?.get(storageTag)
+      const isFailed = validationStatus === 'invalid'
+      const displayValue = '$' + part.value.slice(1).toUpperCase()
+
+      return (
+        <span key={key} className="inline-flex items-center">
+          <Link
+            href={`/hashtag?tag=${encodeURIComponent(storageTag)}`}
+            onClick={(e) => e.stopPropagation()}
+            className={`text-yappr-500 hover:underline ${isFailed ? 'opacity-70' : ''}`}
+          >
+            {displayValue}
+          </Link>
+          {isFailed && onFailedHashtagClick && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                onFailedHashtagClick(storageTag)
+              }}
+              className="ml-0.5 text-amber-500 hover:text-amber-600 transition-colors"
+              title="Cashtag not registered - click to fix"
+            >
+              <ExclamationTriangleIcon className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </span>
+      )
+    }
+
+    if (part.type === 'mention') {
+      return (
+        <span key={key} className="text-yappr-500">
+          {part.value}
+        </span>
+      )
+    }
+
+    // text
+    return <Fragment key={key}>{part.value}</Fragment>
+  }
+
+  // Render children array (for bold/italic inner content)
+  const renderChildren = (children: ContentPart[]): React.ReactNode => {
+    return children.map((child, i) => renderInlinePart(child, i))
+  }
+
   return (
     <div className={className}>
       <div className="whitespace-pre-wrap break-words">
@@ -147,7 +317,7 @@ export function PostContent({
           if (part.type === 'bold') {
             return (
               <strong key={index} className="font-semibold">
-                {part.value}
+                {part.children ? renderChildren(part.children) : part.value}
               </strong>
             )
           }
@@ -155,7 +325,7 @@ export function PostContent({
           if (part.type === 'italic') {
             return (
               <em key={index} className="italic">
-                {part.value}
+                {part.children ? renderChildren(part.children) : part.value}
               </em>
             )
           }
@@ -171,108 +341,7 @@ export function PostContent({
             )
           }
 
-          if (part.type === 'url') {
-            // Ensure URL has protocol for href
-            const href = part.value.startsWith('www.')
-              ? `https://${part.value}`
-              : part.value
-            // Clean up trailing punctuation that might have been captured
-            const cleanHref = href.replace(/[.,;:!?)]+$/, '')
-            const cleanDisplay = part.value.replace(/[.,;:!?)]+$/, '')
-            const trailingPunctuation = part.value.slice(cleanDisplay.length)
-
-            return (
-              <Fragment key={index}>
-                <a
-                  href={cleanHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  className="text-yappr-500 hover:underline break-all"
-                >
-                  {cleanDisplay}
-                </a>
-                {trailingPunctuation}
-              </Fragment>
-            )
-          }
-
-          if (part.type === 'hashtag') {
-            const tag = part.value.slice(1).toLowerCase() // Remove # and lowercase
-            const validationStatus = hashtagValidations?.get(tag)
-            const isFailed = validationStatus === 'invalid'
-
-            return (
-              <span key={index} className="inline-flex items-center">
-                <Link
-                  href={`/hashtag?tag=${encodeURIComponent(tag)}`}
-                  onClick={(e) => e.stopPropagation()}
-                  className={`text-yappr-500 hover:underline ${isFailed ? 'opacity-70' : ''}`}
-                >
-                  {part.value}
-                </Link>
-                {isFailed && onFailedHashtagClick && (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      e.preventDefault()
-                      onFailedHashtagClick(tag)
-                    }}
-                    className="ml-0.5 text-amber-500 hover:text-amber-600 transition-colors"
-                    title="Hashtag not registered - click to fix"
-                  >
-                    <ExclamationTriangleIcon className="h-3.5 w-3.5" />
-                  </button>
-                )}
-              </span>
-            )
-          }
-
-          if (part.type === 'cashtag') {
-            // Cashtags are stored with _cashtag suffix (e.g., $DASH -> dash_cashtag)
-            const storageTag = cashtagDisplayToStorage(part.value) // e.g., "dash_cashtag"
-            const validationStatus = hashtagValidations?.get(storageTag)
-            const isFailed = validationStatus === 'invalid'
-            // Display cashtags in uppercase
-            const displayValue = '$' + part.value.slice(1).toUpperCase()
-
-            return (
-              <span key={index} className="inline-flex items-center">
-                <Link
-                  href={`/hashtag?tag=${encodeURIComponent(storageTag)}`}
-                  onClick={(e) => e.stopPropagation()}
-                  className={`text-yappr-500 hover:underline ${isFailed ? 'opacity-70' : ''}`}
-                >
-                  {displayValue}
-                </Link>
-                {isFailed && onFailedHashtagClick && (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      e.preventDefault()
-                      onFailedHashtagClick(storageTag)
-                    }}
-                    className="ml-0.5 text-amber-500 hover:text-amber-600 transition-colors"
-                    title="Cashtag not registered - click to fix"
-                  >
-                    <ExclamationTriangleIcon className="h-3.5 w-3.5" />
-                  </button>
-                )}
-              </span>
-            )
-          }
-
-          if (part.type === 'mention') {
-            // For mentions, we'd need to resolve the username to an identity ID
-            // For now, just style it but don't link
-            return (
-              <span key={index} className="text-yappr-500">
-                {part.value}
-              </span>
-            )
-          }
-
-          return <Fragment key={index}>{part.value}</Fragment>
+          return renderInlinePart(part, index)
         })}
       </div>
       {/* Link preview */}


### PR DESCRIPTION
Update PostContent component to parse and render text formatting that was already supported in the compose modal preview. Posts now display **bold**, *italic*, and `code` formatting across all pages (feed, profile, post detail, etc.) matching the compose preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced text formatting with support for nested bold, italic, and code styles.
  * Improved hashtag and cashtag rendering with warning indicators for better visibility.

* **Improvements**
  * Better URL normalization, punctuation handling, and display formatting.
  * Refined parsing of mentions and inline content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->