### PR TITLE
Increase feed auto-pagination threshold from 5 to 20

### DIFF
--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -292,7 +292,7 @@ function FeedPage() {
       } else {
         // For You feed - get all posts and reposts
         // Auto-paginate to ensure we have enough non-reply posts after filtering
-        const MIN_NON_REPLY_POSTS = 5 // Minimum posts to show before requiring "Load More"
+        const MIN_NON_REPLY_POSTS = 20 // Minimum posts to show before requiring "Load More"
         const MAX_FETCH_ITERATIONS = 5 // Safety limit to prevent infinite loops
         const dashClient = getDashPlatformClient()
 


### PR DESCRIPTION
The minimum number of non-reply posts required before stopping auto-pagination was set too low at 5. Increased to 20 to ensure users see a more substantial feed before needing to click "Load More".