### PR TITLE
Fix 'Create your profile' link to navigate to user profile edit mode

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -320,6 +320,20 @@ function UserProfileContent() {
     loadProfileData()
   }, [userId, enrichProgressively])
 
+  // Handle edit URL parameter for deep linking to edit mode
+  useEffect(() => {
+    if (!isOwnProfile || isLoading) return
+
+    const editParam = searchParams.get('edit')
+    if (editParam === 'true' && !isEditingProfile) {
+      handleStartEdit()
+      // Remove edit param from URL after triggering edit mode
+      const url = new URL(window.location.href)
+      url.searchParams.delete('edit')
+      window.history.replaceState({}, '', url.toString())
+    }
+  }, [isOwnProfile, isLoading, searchParams, isEditingProfile])
+
   // Handle tip URL parameter for deep linking
   useEffect(() => {
     if (!profile?.paymentUris || profile.paymentUris.length === 0) return

--- a/components/layout/right-sidebar.tsx
+++ b/components/layout/right-sidebar.tsx
@@ -106,7 +106,7 @@ export function RightSidebar() {
           </p>
           <ul className="space-y-2">
             <li>
-              <Link href="/settings?section=account" className="text-yappr-500 hover:text-yappr-600 dark:hover:text-yappr-400 hover:underline">
+              <Link href={user?.identityId ? `/user?id=${user.identityId}&edit=true` : '/settings?section=account'} className="text-yappr-500 hover:text-yappr-600 dark:hover:text-yappr-400 hover:underline">
                 • Create your profile
               </Link>
             </li>


### PR DESCRIPTION
The Getting Started link now sends logged-in users to their profile page with edit mode active (/user?id=...&edit=true) instead of settings.