### PR TITLE
Remove redundant ternary in reply-to span className

### DIFF
--- a/components/post/post-card.tsx
+++ b/components/post/post-card.tsx
@@ -531,7 +531,7 @@ export function PostCard({ post, hideAvatar = false, isOwnPost: isOwnPostProp, e
               onClick={(e) => e.stopPropagation()}
               className="text-sm text-gray-500 hover:underline mt-1 block"
             >
-              Replying to <span className={replyToDisplay.showAt ? "text-yappr-500" : "text-yappr-500"}>
+              Replying to <span className="text-yappr-500">
                 {replyToDisplay.showAt ? `@${replyToDisplay.text}` : replyToDisplay.text}
               </span>
             </Link>


### PR DESCRIPTION
Both branches of the ternary returned the same value "text-yappr-500", making the conditional unnecessary. Simplified to use the class directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code cleanup and simplification with no visible impact to end-users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->