### PR TITLE
Add subtle link to Dash Platform GitHub on footer image

### DIFF
--- a/components/layout/right-sidebar.tsx
+++ b/components/layout/right-sidebar.tsx
@@ -180,22 +180,28 @@ export function RightSidebar() {
       </div>
 
       <div className="px-4 py-3 flex justify-center">
-        <Image
-          src="/pbde-light.png"
-          alt="Powered by Dash Evolution"
-          width={140}
-          height={47}
-          className="dark:hidden"
-          style={{ width: 'auto', height: 'auto' }}
-        />
-        <Image
-          src="/pbde-dark.png"
-          alt="Powered by Dash Evolution"
-          width={140}
-          height={47}
-          className="hidden dark:block"
-          style={{ width: 'auto', height: 'auto' }}
-        />
+        <a
+          href="https://github.com/dashpay/platform"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Image
+            src="/pbde-light.png"
+            alt="Powered by Dash Evolution"
+            width={140}
+            height={47}
+            className="dark:hidden"
+            style={{ width: 'auto', height: 'auto' }}
+          />
+          <Image
+            src="/pbde-dark.png"
+            alt="Powered by Dash Evolution"
+            width={140}
+            height={47}
+            className="hidden dark:block"
+            style={{ width: 'auto', height: 'auto' }}
+          />
+        </a>
       </div>
 
       <div className="px-4 py-2 text-xs text-gray-500 space-x-2">


### PR DESCRIPTION
Wrap the "Powered by Dash Evolution" image in the right sidebar with a link to github.com/dashpay/platform. The only visual indication is the cursor changing to pointer on hover, making it a small easter egg for curious users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vendor images are now interactive and link to the GitHub repository, opening in a new tab for convenient access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->