### PR TITLE
Add pagination support for Dash Platform queries

### DIFF
--- a/lib/services/block-service.ts
+++ b/lib/services/block-service.ts
@@ -224,6 +224,11 @@ class BlockService extends BaseDocumentService<BlockDocument> {
 
   /**
    * Get bloom filters for multiple users in batch.
+   *
+   * TODO: This query uses 'in' clause which doesn't support reliable pagination.
+   * The SDK returns incomplete results when subtrees are empty but still count against the limit.
+   * Once SDK provides better 'in' query support (e.g., a flag indicating result completeness),
+   * implement pagination here to handle cases where results exceed the limit.
    */
   async getBloomFiltersBatch(userIds: string[]): Promise<Map<string, BloomFilter>> {
     const result = new Map<string, BloomFilter>()
@@ -724,6 +729,11 @@ class BlockService extends BaseDocumentService<BlockDocument> {
 
   /**
    * Query blocks using 'in' operator for efficient batch lookup.
+   *
+   * TODO: This query uses 'in' clause which doesn't support reliable pagination.
+   * The SDK returns incomplete results when subtrees are empty but still count against the limit.
+   * Once SDK provides better 'in' query support (e.g., a flag indicating result completeness),
+   * implement pagination here to handle cases where results exceed the limit.
    */
   private async queryBlockedIn(blockerId: string, targetIds: string[]): Promise<BlockDocument[]> {
     if (targetIds.length === 0) return []
@@ -746,6 +756,11 @@ class BlockService extends BaseDocumentService<BlockDocument> {
   /**
    * Query inherited blocks for multiple targets from multiple blockers.
    * Queries each blocker in parallel since Platform only supports one 'in' clause per query.
+   *
+   * TODO: This query uses 'in' clause which doesn't support reliable pagination.
+   * The SDK returns incomplete results when subtrees are empty but still count against the limit.
+   * Once SDK provides better 'in' query support (e.g., a flag indicating result completeness),
+   * implement pagination here to handle cases where results exceed the limit.
    */
   private async queryInheritedBlocksBatch(
     targetIds: string[],

--- a/lib/services/dpns-service.ts
+++ b/lib/services/dpns-service.ts
@@ -123,6 +123,11 @@ class DpnsService {
   /**
    * Batch resolve usernames for multiple identity IDs (reverse lookup)
    * Uses 'in' operator for efficient single-query resolution
+   *
+   * TODO: This query uses 'in' clause which doesn't support reliable pagination.
+   * The SDK returns incomplete results when subtrees are empty but still count against the limit.
+   * Once SDK provides better 'in' query support (e.g., a flag indicating result completeness),
+   * implement pagination here to handle cases where results exceed the limit.
    */
   async resolveUsernamesBatch(identityIds: string[]): Promise<Map<string, string | null>> {
     const results = new Map<string, string | null>();

--- a/lib/services/pagination-utils.ts
+++ b/lib/services/pagination-utils.ts
@@ -1,0 +1,166 @@
+/**
+ * Pagination utilities for Dash Platform document queries.
+ *
+ * The SDK's startAfter cursor-based pagination requires:
+ * - An orderBy clause on the query
+ * - The last document's $id as the startAfter value
+ *
+ * These utilities handle automatic pagination through all results
+ * for both counting and fetching complete lists.
+ */
+
+import { normalizeSDKResponse } from './sdk-helpers';
+
+export interface PaginateOptions {
+  /** Maximum results to return (safety limit). Default: 1000 */
+  maxResults?: number;
+  /** Page size per query. Default: 100 */
+  pageSize?: number;
+}
+
+export interface PaginateCountResult {
+  count: number;
+  /** True if we hit maxResults before exhausting all documents */
+  reachedLimit: boolean;
+}
+
+export interface PaginateFetchResult<T> {
+  documents: T[];
+  /** True if we hit maxResults before exhausting all documents */
+  reachedLimit: boolean;
+}
+
+// Use any for SDK type since EvoSDK has complex generic typing
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SDK = any;
+
+/**
+ * Paginate through all documents matching a query and return the count.
+ * Used for count methods that need accurate totals.
+ *
+ * @param sdk - The EvoSDK instance
+ * @param queryBuilder - Function that returns the query object, accepting optional startAfter cursor
+ * @param options - Pagination options
+ * @returns Count result with total and whether limit was reached
+ *
+ * @example
+ * ```typescript
+ * const { count } = await paginateCount(sdk, (startAfter) => ({
+ *   dataContractId: contractId,
+ *   documentTypeName: 'like',
+ *   where: [['$ownerId', '==', userId]],
+ *   orderBy: [['$createdAt', 'asc']],
+ * }));
+ * ```
+ */
+export async function paginateCount(
+  sdk: SDK,
+  queryBuilder: (startAfter?: string) => Record<string, unknown>,
+  options: PaginateOptions = {}
+): Promise<PaginateCountResult> {
+  const { maxResults = 1000, pageSize = 100 } = options;
+
+  let totalCount = 0;
+  let startAfter: string | undefined = undefined;
+  let reachedLimit = false;
+
+  while (totalCount < maxResults) {
+    const query = queryBuilder(startAfter);
+    query.limit = pageSize;
+    if (startAfter) {
+      query.startAfter = startAfter;
+    }
+
+    const response = await sdk.documents.query(query);
+    const documents = normalizeSDKResponse(response);
+
+    totalCount += documents.length;
+
+    // Check if we've reached the end (fewer documents than requested)
+    if (documents.length < pageSize) {
+      break;
+    }
+
+    // Check if we've hit the safety limit
+    if (totalCount >= maxResults) {
+      reachedLimit = true;
+      break;
+    }
+
+    // Get cursor for next page
+    const lastDoc = documents[documents.length - 1];
+    if (!lastDoc.$id) break;
+    startAfter = lastDoc.$id as string;
+  }
+
+  return { count: totalCount, reachedLimit };
+}
+
+/**
+ * Paginate through all documents and return them.
+ * Used for list methods that need complete data.
+ *
+ * @param sdk - The EvoSDK instance
+ * @param queryBuilder - Function that returns the query object, accepting optional startAfter cursor
+ * @param transformFn - Function to transform raw documents to typed objects
+ * @param options - Pagination options
+ * @returns Fetch result with documents array and whether limit was reached
+ *
+ * @example
+ * ```typescript
+ * const { documents } = await paginateFetchAll(
+ *   sdk,
+ *   (startAfter) => ({
+ *     dataContractId: contractId,
+ *     documentTypeName: 'follow',
+ *     where: [['followingId', '==', userId]],
+ *     orderBy: [['$createdAt', 'asc']],
+ *   }),
+ *   (doc) => transformDocument(doc)
+ * );
+ * ```
+ */
+export async function paginateFetchAll<T>(
+  sdk: SDK,
+  queryBuilder: (startAfter?: string) => Record<string, unknown>,
+  transformFn: (doc: Record<string, unknown>) => T,
+  options: PaginateOptions = {}
+): Promise<PaginateFetchResult<T>> {
+  const { maxResults = 1000, pageSize = 100 } = options;
+
+  const allDocuments: T[] = [];
+  let startAfter: string | undefined = undefined;
+  let reachedLimit = false;
+
+  while (allDocuments.length < maxResults) {
+    const query = queryBuilder(startAfter);
+    query.limit = pageSize;
+    if (startAfter) {
+      query.startAfter = startAfter;
+    }
+
+    const response = await sdk.documents.query(query);
+    const documents = normalizeSDKResponse(response);
+
+    // Transform and collect documents
+    allDocuments.push(...documents.map(transformFn));
+
+    // Check if we've reached the end (fewer documents than requested)
+    if (documents.length < pageSize) {
+      break;
+    }
+
+    // Check if we've hit the safety limit
+    if (allDocuments.length >= maxResults) {
+      reachedLimit = true;
+      break;
+    }
+
+    // Get cursor for next page
+    const lastDoc = documents[documents.length - 1];
+    if (!lastDoc.$id) break;
+    startAfter = lastDoc.$id as string;
+  }
+
+  return { documents: allDocuments, reachedLimit };
+}

--- a/lib/services/profile-service.ts
+++ b/lib/services/profile-service.ts
@@ -400,6 +400,11 @@ class ProfileService extends BaseDocumentService<User> {
 
   /**
    * Get profiles by array of identity IDs
+   *
+   * TODO: This query uses 'in' clause which doesn't support reliable pagination.
+   * The SDK returns incomplete results when subtrees are empty but still count against the limit.
+   * Once SDK provides better 'in' query support (e.g., a flag indicating result completeness),
+   * implement pagination here to handle cases where results exceed the limit.
    */
   async getProfilesByIdentityIds(identityIds: string[]): Promise<ProfileDocument[]> {
     try {

--- a/lib/services/unified-profile-service.ts
+++ b/lib/services/unified-profile-service.ts
@@ -278,6 +278,11 @@ class UnifiedProfileService extends BaseDocumentService<User> {
 
   /**
    * Batch fetch avatar URLs for multiple users
+   *
+   * TODO: This query uses 'in' clause which doesn't support reliable pagination.
+   * The SDK returns incomplete results when subtrees are empty but still count against the limit.
+   * Once SDK provides better 'in' query support (e.g., a flag indicating result completeness),
+   * implement pagination here to handle cases where results exceed the limit.
    */
   private async fetchAvatarUrlsBatch(userIds: string[]): Promise<Map<string, string>> {
     const result = new Map<string, string>();


### PR DESCRIPTION
Implement automatic pagination to ensure accurate counts and complete data retrieval when results exceed single query limits.

Changes:
- Add pagination-utils.ts with paginateCount() and paginateFetchAll() utilities
- Update count methods to paginate for accurate totals:
  - countUserLikes, countFollowers, countFollowing, countUserPosts, countAllPosts, getPostCountByHashtag
- Update list methods to paginate for complete results:
  - getPostLikes, getUserLikes, getFollowers, getFollowing, getPostReposts, getUserReposts, getUserBookmarks, getPostIdsByHashtag, getRecentHashtags
- Add TODO comments to 13 'in' clause query methods that need special handling once the SDK provides better support

The 'in' clause queries cannot reliably paginate because empty subtrees still count against the limit. These are documented for future SDK updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support to improve handling of large result sets across bookmarks, followers, likes, reposts, and hashtags.

* **Refactor**
  * Updated data retrieval mechanisms to use cursor-based pagination for more reliable and complete results.

* **Documentation**
  * Added notes documenting current query limitations and planned improvements for edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->