### PR TITLE
Display larger preview format for direct image URLs

### DIFF
--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -345,7 +345,7 @@ export function PostContent({
         })}
       </div>
       {/* Link preview */}
-      {!disableLinkPreview && previewLoading && <LinkPreviewSkeleton />}
+      {!disableLinkPreview && previewLoading && <LinkPreviewSkeleton url={firstUrl ?? undefined} />}
       {!disableLinkPreview && previewData && (
         <LinkPreview data={previewData} />
       )}

--- a/hooks/use-link-preview.ts
+++ b/hooks/use-link-preview.ts
@@ -38,6 +38,25 @@ const SKIP_DOMAINS = [
   '0.0.0.0',
 ]
 
+// Common image file extensions
+const IMAGE_EXTENSIONS = [
+  '.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg', '.ico', '.avif'
+]
+
+/**
+ * Check if a URL points directly to an image file based on its extension.
+ * This is used to render direct image links with a larger preview format.
+ */
+export function isDirectImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    const pathname = parsed.pathname.toLowerCase()
+    return IMAGE_EXTENSIONS.some(ext => pathname.endsWith(ext))
+  } catch {
+    return false
+  }
+}
+
 function shouldSkipUrl(url: string): boolean {
   try {
     const parsed = new URL(url)


### PR DESCRIPTION
When a link preview URL points directly to an image file (e.g., .gif, .jpg, .png), display it in a larger prominent format instead of the compact article preview layout. This makes image links more visually appropriate for their content type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Link previews now intelligently distinguish between direct image URLs and standard pages
  * Direct images display in an enhanced large-image layout while pages use the compact preview format
  * Loading skeletons adapt to show appropriate placeholders based on content type

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->