### PR TITLE
Remove non-functional image and emoji buttons from message input

### DIFF
--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -5,8 +5,6 @@ import { motion } from 'framer-motion'
 import {
   MagnifyingGlassIcon,
   PaperAirplaneIcon,
-  PhotoIcon,
-  FaceSmileIcon,
   InformationCircleIcon,
   EllipsisHorizontalIcon,
   PlusIcon
@@ -520,13 +518,6 @@ function MessagesPage() {
                 }}
                 className="flex items-center gap-1 sm:gap-2"
               >
-                <button
-                  type="button"
-                  className="p-2 hover:bg-gray-100 dark:hover:bg-gray-900 rounded-full flex-shrink-0"
-                >
-                  <PhotoIcon className="h-5 w-5" />
-                </button>
-
                 <Input
                   type="text"
                   placeholder="Type a message..."
@@ -535,13 +526,6 @@ function MessagesPage() {
                   disabled={isSending}
                   className="flex-1 min-w-0"
                 />
-
-                <button
-                  type="button"
-                  className="p-2 hover:bg-gray-100 dark:hover:bg-gray-900 rounded-full flex-shrink-0 hidden sm:block"
-                >
-                  <FaceSmileIcon className="h-5 w-5" />
-                </button>
 
                 <Button
                   type="submit"


### PR DESCRIPTION
These buttons in the Messages page had no click handlers and provided no functionality, causing confusion for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed media attachment and emoji picker controls from the message input interface. Core message-sending functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->