### PR TITLE
Change link preview toggle to fully disable previews when off

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -51,8 +51,8 @@ function SettingsPage() {
   const searchParams = useSearchParams()
   const { user, logout } = useAuth()
   const { theme, setTheme } = useTheme()
-  const richLinkPreviews = useSettingsStore((s) => s.richLinkPreviews)
-  const setRichLinkPreviews = useSettingsStore((s) => s.setRichLinkPreviews)
+  const linkPreviews = useSettingsStore((s) => s.linkPreviews)
+  const setLinkPreviews = useSettingsStore((s) => s.setLinkPreviews)
 
   // Derive active section from URL search params
   const sectionParam = searchParams.get('section')
@@ -303,20 +303,20 @@ function SettingsPage() {
 
           <div className="flex items-center justify-between">
             <div>
-              <p className="font-medium">Rich Link Previews</p>
-              <p className="text-sm text-gray-500">Fetch page titles, descriptions, and images for links</p>
+              <p className="font-medium">Link Previews</p>
+              <p className="text-sm text-gray-500">Show previews with titles, descriptions, and images for links</p>
             </div>
             <Switch.Root
-              checked={richLinkPreviews}
-              onCheckedChange={setRichLinkPreviews}
+              checked={linkPreviews}
+              onCheckedChange={setLinkPreviews}
               className={`w-11 h-6 rounded-full relative transition-colors ${
-                richLinkPreviews ? 'bg-yappr-500' : 'bg-gray-200 dark:bg-gray-800'
+                linkPreviews ? 'bg-yappr-500' : 'bg-gray-200 dark:bg-gray-800'
               }`}
             >
               <Switch.Thumb className="block w-5 h-5 bg-white rounded-full transition-transform data-[state=checked]:translate-x-5 translate-x-0.5" />
             </Switch.Root>
           </div>
-          {richLinkPreviews && (
+          {linkPreviews && (
             <div className="ml-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
               <p className="text-sm text-amber-800 dark:text-amber-200">
                 <strong>Privacy note:</strong> {CORS_PROXY_INFO.warning}

--- a/components/post/link-preview.tsx
+++ b/components/post/link-preview.tsx
@@ -7,6 +7,90 @@ import { LinkIcon, SparklesIcon } from '@heroicons/react/24/outline'
 import { useSettingsStore } from '@/lib/store'
 import { CORS_PROXY_INFO, isDirectImageUrl } from '@/hooks/use-link-preview'
 
+/**
+ * Prompt shown when link previews are disabled but a URL exists
+ * Allows users to enable link previews with privacy disclosure
+ */
+export function LinkPreviewEnablePrompt() {
+  const [showEnableHint, setShowEnableHint] = useState(false)
+  const setLinkPreviews = useSettingsStore((s) => s.setLinkPreviews)
+
+  const handleEnablePreviews = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setLinkPreviews(true)
+  }
+
+  return (
+    <div className="mt-2 text-xs text-neutral-400 dark:text-neutral-500">
+      {showEnableHint ? (
+        <div className="p-2 bg-neutral-100 dark:bg-neutral-800 rounded-lg space-y-2">
+          <p className="text-neutral-600 dark:text-neutral-400">
+            {CORS_PROXY_INFO.warning}
+          </p>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleEnablePreviews}
+              className="text-yappr-500 hover:text-yappr-600 font-medium"
+            >
+              Enable link previews
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                setShowEnableHint(false)
+              }}
+              className="text-neutral-500 hover:text-neutral-600"
+            >
+              Cancel
+            </button>
+          </div>
+          <p className="text-neutral-500 text-[10px]">
+            Uses:{' '}
+            {CORS_PROXY_INFO.proxies.map((p, i) => (
+              <span key={p.name}>
+                {i > 0 && ', '}
+                <a
+                  href={p.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-neutral-600"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {p.name}
+                </a>
+              </span>
+            ))}
+          </p>
+          <p className="text-neutral-500 text-[10px]">
+            You can change this anytime in{' '}
+            <Link
+              href="/settings"
+              className="underline hover:text-neutral-600"
+              onClick={(e) => e.stopPropagation()}
+            >
+              Settings
+            </Link>
+          </p>
+        </div>
+      ) : (
+        <button
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setShowEnableHint(true)
+          }}
+          className="flex items-center gap-1 hover:text-neutral-500 dark:hover:text-neutral-400 transition-colors"
+        >
+          <SparklesIcon className="h-3 w-3" />
+          <span>Enable link previews</span>
+        </button>
+      )}
+    </div>
+  )
+}
+
 // Note: We use next/image for favicon (small, fixed size) but regular img
 // for preview images so we can check naturalWidth/Height on load
 
@@ -53,10 +137,6 @@ export function LinkPreview({ data, className = '' }: LinkPreviewProps) {
     return false
   })
   const [faviconError, setFaviconError] = useState(false)
-  const [showEnableHint, setShowEnableHint] = useState(false)
-
-  const richLinkPreviews = useSettingsStore((s) => s.richLinkPreviews)
-  const setRichLinkPreviews = useSettingsStore((s) => s.setRichLinkPreviews)
 
   const safeUrl = sanitizeUrl(data.url)
 
@@ -75,8 +155,6 @@ export function LinkPreview({ data, className = '' }: LinkPreviewProps) {
 
   // Hide image if error, too small, or dimensions indicate it's not useful
   const showImage = data.image && !imageError && !imageTooSmall
-  const hasRichContent = data.title || data.description || data.image
-  const isBasicPreview = !hasRichContent
 
   // Check if URL points directly to an image file
   const isDirectImage = isDirectImageUrl(data.url)
@@ -87,12 +165,6 @@ export function LinkPreview({ data, className = '' }: LinkPreviewProps) {
     if (img.naturalWidth < MIN_IMAGE_SIZE || img.naturalHeight < MIN_IMAGE_SIZE) {
       setImageTooSmall(true)
     }
-  }
-
-  const handleEnableRichPreviews = (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setRichLinkPreviews(true)
   }
 
   // Direct image URL - use larger layout with prominent image display
@@ -201,76 +273,6 @@ export function LinkPreview({ data, className = '' }: LinkPreviewProps) {
           </div>
         )}
       </a>
-
-      {/* Enable rich previews hint - only show for basic previews */}
-      {isBasicPreview && !richLinkPreviews && (
-        <div className="mt-1.5 text-xs text-neutral-400 dark:text-neutral-500">
-          {showEnableHint ? (
-            <div className="p-2 bg-neutral-100 dark:bg-neutral-800 rounded-lg space-y-2">
-              <p className="text-neutral-600 dark:text-neutral-400">
-                {CORS_PROXY_INFO.warning}
-              </p>
-              <div className="flex items-center gap-3">
-                <button
-                  onClick={handleEnableRichPreviews}
-                  className="text-yappr-500 hover:text-yappr-600 font-medium"
-                >
-                  Enable rich previews
-                </button>
-                <button
-                  onClick={(e) => {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    setShowEnableHint(false)
-                  }}
-                  className="text-neutral-500 hover:text-neutral-600"
-                >
-                  Cancel
-                </button>
-              </div>
-              <p className="text-neutral-500 text-[10px]">
-                Uses:{' '}
-                {CORS_PROXY_INFO.proxies.map((p, i) => (
-                  <span key={p.name}>
-                    {i > 0 && ', '}
-                    <a
-                      href={p.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline hover:text-neutral-600"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {p.name}
-                    </a>
-                  </span>
-                ))}
-              </p>
-              <p className="text-neutral-500 text-[10px]">
-                You can change this anytime in{' '}
-                <Link
-                  href="/settings"
-                  className="underline hover:text-neutral-600"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  Settings
-                </Link>
-              </p>
-            </div>
-          ) : (
-            <button
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                setShowEnableHint(true)
-              }}
-              className="flex items-center gap-1 hover:text-neutral-500 dark:hover:text-neutral-400 transition-colors"
-            >
-              <SparklesIcon className="h-3 w-3" />
-              <span>Enable rich previews</span>
-            </button>
-          )}
-        </div>
-      )}
     </div>
   )
 }

--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { Fragment, useMemo } from 'react'
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { HashtagValidationStatus } from '@/hooks/use-hashtag-validation'
-import { LinkPreview, LinkPreviewSkeleton } from './link-preview'
+import { LinkPreview, LinkPreviewSkeleton, LinkPreviewEnablePrompt } from './link-preview'
 import { useLinkPreview, extractFirstUrl } from '@/hooks/use-link-preview'
 import { useSettingsStore } from '@/lib/store'
 import { cashtagDisplayToStorage } from '@/lib/post-helpers'
@@ -40,13 +40,15 @@ export function PostContent({
   onFailedHashtagClick,
   disableLinkPreview = false
 }: PostContentProps) {
-  const richLinkPreviews = useSettingsStore((s) => s.richLinkPreviews)
+  const linkPreviews = useSettingsStore((s) => s.linkPreviews)
 
   // Extract first URL for preview
   const firstUrl = useMemo(() => extractFirstUrl(content), [content])
+
+  // Only fetch preview if link previews are enabled
   const { data: previewData, loading: previewLoading } = useLinkPreview(
     firstUrl,
-    { disabled: disableLinkPreview, richPreview: richLinkPreviews }
+    { disabled: disableLinkPreview || !linkPreviews }
   )
   const parsedContent = useMemo(() => {
     // Patterns for inline elements (hashtags, cashtags, mentions, urls)
@@ -345,9 +347,13 @@ export function PostContent({
         })}
       </div>
       {/* Link preview */}
-      {!disableLinkPreview && previewLoading && <LinkPreviewSkeleton url={firstUrl ?? undefined} />}
-      {!disableLinkPreview && previewData && (
+      {!disableLinkPreview && linkPreviews && previewLoading && <LinkPreviewSkeleton url={firstUrl ?? undefined} />}
+      {!disableLinkPreview && linkPreviews && previewData && (
         <LinkPreview data={previewData} />
+      )}
+      {/* Enable link previews prompt - shown when disabled and URL exists */}
+      {!disableLinkPreview && !linkPreviews && firstUrl && (
+        <LinkPreviewEnablePrompt />
       )}
     </div>
   )

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -120,16 +120,16 @@ export const useAppStore = create<AppState>((set) => ({
 
 // Settings store with localStorage persistence
 interface SettingsState {
-  /** Enable rich link previews (fetches metadata via third-party proxy) */
-  richLinkPreviews: boolean
-  setRichLinkPreviews: (enabled: boolean) => void
+  /** Enable link previews (fetches metadata via third-party proxy) */
+  linkPreviews: boolean
+  setLinkPreviews: (enabled: boolean) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
     (set) => ({
-      richLinkPreviews: false, // Disabled by default for privacy
-      setRichLinkPreviews: (enabled) => set({ richLinkPreviews: enabled }),
+      linkPreviews: false, // Disabled by default for privacy
+      setLinkPreviews: (enabled) => set({ linkPreviews: enabled }),
     }),
     {
       name: 'yappr-settings',


### PR DESCRIPTION
Previously, link previews showed a basic preview (domain + favicon) by default and users could opt-in to "rich" previews with full metadata.

Now the toggle fully controls whether any preview is shown:
- When disabled: no preview shown, just an "Enable link previews" prompt
- When enabled: fetch full metadata (title, description, image) via proxy

This simplifies the UX and gives users clearer control over privacy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an enable prompt for link previews when disabled, displaying privacy proxy details and navigation to settings.

* **Updates**
  * Renamed "Rich Link Previews" to "Link Previews" throughout the settings interface.
  * Updated feature descriptions for improved clarity and consistency.
  * Streamlined link preview detection and rendering logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->