### PR TITLE
Remove self from following feed

### DIFF
--- a/lib/services/post-service.ts
+++ b/lib/services/post-service.ts
@@ -429,8 +429,7 @@ class PostService extends BaseDocumentService<Post> {
       const { followService } = await import('./follow-service');
       const following = await followService.getFollowing(userId, { limit: 100 });
 
-      // Include the current user's ID so they see their own posts in the feed
-      const followingIds = [...following.map(f => f.followingId), userId];
+      const followingIds = following.map(f => f.followingId);
 
       if (followingIds.length === 0) {
         return { documents: [], nextCursor: undefined, prevCursor: undefined };


### PR DESCRIPTION
Users will no longer see their own posts in the Following feed. The explicit userId addition has been removed from getFollowingFeed.