### PR TITLE
Fix duplicate key backup dialog during registration

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -197,11 +197,13 @@ export default function LoginPage() {
         await login(identityId, credential, { rememberMe })
 
         // Prompt for on-chain backup if none exists (and not already prompted this session)
-        if (encryptedKeyService.isConfigured() && !sessionStorage.getItem('yappr_backup_prompt_shown')) {
+        // Only show for users who already have a DPNS username - new users without a username
+        // will be prompted after completing DPNS registration in the username modal
+        if (resolvedIdentity?.dpnsUsername && encryptedKeyService.isConfigured() && !sessionStorage.getItem('yappr_backup_prompt_shown')) {
           const hasBackup = await encryptedKeyService.hasBackup(identityId)
           if (!hasBackup) {
             sessionStorage.setItem('yappr_backup_prompt_shown', 'true')
-            openBackupModal(identityId, resolvedIdentity?.dpnsUsername || '', credential, false)
+            openBackupModal(identityId, resolvedIdentity.dpnsUsername, credential, false)
           }
         }
       } else {

--- a/components/dpns/username-modal.tsx
+++ b/components/dpns/username-modal.tsx
@@ -6,6 +6,8 @@ import { X } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAuth } from '@/contexts/auth-context'
 import { useDpnsRegistration } from '@/hooks/use-dpns-registration'
+import { useKeyBackupModal } from '@/hooks/use-key-backup-modal'
+import { encryptedKeyService } from '@/lib/services/encrypted-key-service'
 
 import { DpnsRegistrationWizard } from './registration-wizard'
 
@@ -29,14 +31,42 @@ export function UsernameModal({ isOpen, onClose, customIdentityId }: UsernameMod
     }
   }, [isOpen, reset])
 
-  const handleSkip = () => {
+  const handleSkip = async () => {
     sessionStorage.setItem('yappr_skip_dpns', 'true')
     onClose()
+
+    // Prompt for key backup if the feature is configured (same as after registration)
+    if (encryptedKeyService.isConfigured()) {
+      const hasBackup = await encryptedKeyService.hasBackup(currentIdentityId)
+      if (!hasBackup) {
+        const { getPrivateKey } = await import('@/lib/secure-storage')
+        const privateKey = getPrivateKey(currentIdentityId)
+        if (privateKey) {
+          useKeyBackupModal.getState().open(currentIdentityId, '', privateKey)
+          return // Don't redirect yet - let the backup modal handle it
+        }
+      }
+    }
+
     router.push('/profile/create')
   }
 
-  const handleComplete = () => {
+  const handleComplete = async () => {
     onClose()
+
+    // Prompt for key backup if the feature is configured
+    if (encryptedKeyService.isConfigured()) {
+      const hasBackup = await encryptedKeyService.hasBackup(currentIdentityId)
+      if (!hasBackup) {
+        const { getPrivateKey } = await import('@/lib/secure-storage')
+        const privateKey = getPrivateKey(currentIdentityId)
+        if (privateKey) {
+          // Note: redirectOnClose=true by default, so modal will redirect to /profile/create
+          // The wizard also redirects there, but that's fine - it's a no-op
+          useKeyBackupModal.getState().open(currentIdentityId, user?.dpnsUsername || '', privateKey)
+        }
+      }
+    }
   }
 
   return (


### PR DESCRIPTION
Only show the key backup modal from the login page for users who already have a DPNS username. New users without a username will see the username modal first, which already triggers the key backup modal after successful registration - preventing the dialog from appearing twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On-chain backup prompt now appears only when a DPNS username is present, reducing irrelevant prompts during login.
  * Backup modal reliably receives the DPNS username from the resolved identity, improving backup flow correctness.

* **New Features**
  * After username actions, users may be prompted to complete a key backup when backup is configured and not yet completed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->