### PR TITLE
Fix user page to show skeleton loading state for display name

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -117,7 +117,7 @@ function UserProfileContent() {
   const displayName = profile?.displayName || (userId ? `User ${userId.slice(-6)}` : 'Unknown')
 
   // Check if display name is still in loading/fallback state
-  const isDisplayNameLoading = isLoading || !profile?.displayName || displayName.startsWith('User ')
+  const isDisplayNameLoading = isLoading || !profile?.displayName
 
   useEffect(() => {
     if (!userId) return


### PR DESCRIPTION
Instead of briefly flashing "User Gv272x" (the fallback format) before the real display name loads, now shows a blurred/pulsing skeleton loader consistent with patterns used elsewhere in the app (e.g., post-card.tsx).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile page loading UX: skeleton placeholders now appear in the header and profile information area while the display name is being fetched, giving clearer visual feedback during data loading; normal display resumes once the name is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->