### PR TITLE
Fix feed state not persisting across navigation

### DIFF
--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils'
 import { ArrowPathIcon } from '@heroicons/react/24/outline'
 import { PostCard } from '@/components/post/post-card'
 import { FeedReplyContext } from '@/components/post/feed-reply-context'
-import { FeedItem, isFeedReplyContext } from '@/lib/types'
+import { FeedItem, isFeedReplyContext, getFeedItemTimestamp } from '@/lib/types'
 import { Sidebar } from '@/components/layout/sidebar'
 import { RightSidebar } from '@/components/layout/right-sidebar'
 import { ComposeModal } from '@/components/compose/compose-modal'
@@ -141,18 +141,7 @@ function FeedPage() {
           }
           // Set newestPostTimestamp so auto-refresh interval works after back navigation
           if (cached.length > 0) {
-            const getItemTimestamp = (item: FeedItem): number => {
-              if (isFeedReplyContext(item)) {
-                return item.reply.createdAt instanceof Date
-                  ? item.reply.createdAt.getTime()
-                  : new Date(item.reply.createdAt).getTime()
-              }
-              const post = item as any
-              return post.createdAt instanceof Date
-                ? post.createdAt.getTime()
-                : new Date(post.createdAt).getTime()
-            }
-            setNewestPostTimestamp(Math.max(...cached.map(getItemTimestamp)))
+            setNewestPostTimestamp(Math.max(...cached.map(getFeedItemTimestamp)))
             setPendingNewPosts([])
           }
           setIsLoading(false)
@@ -647,19 +636,7 @@ function FeedPage() {
         }
         // Track the newest post timestamp for auto-refresh feature
         if (sortedFeedItems.length > 0) {
-          const getItemTimestamp = (item: FeedItem): number => {
-            if (isFeedReplyContext(item)) {
-              return item.reply.createdAt instanceof Date
-                ? item.reply.createdAt.getTime()
-                : new Date(item.reply.createdAt).getTime()
-            }
-            const post = item as any
-            return post.createdAt instanceof Date
-              ? post.createdAt.getTime()
-              : new Date(post.createdAt).getTime()
-          }
-          const newestTimestamp = Math.max(...sortedFeedItems.map(getItemTimestamp))
-          setNewestPostTimestamp(newestTimestamp)
+          setNewestPostTimestamp(Math.max(...sortedFeedItems.map(getFeedItemTimestamp)))
           // Clear any pending new posts when doing a fresh load
           setPendingNewPosts([])
         }
@@ -857,19 +834,7 @@ function FeedPage() {
     if (pendingNewPosts.length === 0) return
 
     // Get the newest timestamp from pending posts
-    const getItemTimestamp = (item: FeedItem): number => {
-      if (isFeedReplyContext(item)) {
-        return item.reply.createdAt instanceof Date
-          ? item.reply.createdAt.getTime()
-          : new Date(item.reply.createdAt).getTime()
-      }
-      const post = item as any
-      return post.createdAt instanceof Date
-        ? post.createdAt.getTime()
-        : new Date(post.createdAt).getTime()
-    }
-
-    const newestPendingTimestamp = Math.max(...pendingNewPosts.map(getItemTimestamp))
+    const newestPendingTimestamp = Math.max(...pendingNewPosts.map(getFeedItemTimestamp))
 
     // Prepend pending posts to current feed
     if (activeTab === 'forYou') {
@@ -990,18 +955,7 @@ function FeedPage() {
         enrichProgressively(postsToEnrich)
         lastEnrichmentUserIdRef.current = user?.identityId
         // Set newestPostTimestamp so auto-refresh interval works after back navigation
-        const getItemTimestamp = (item: FeedItem): number => {
-          if (isFeedReplyContext(item)) {
-            return item.reply.createdAt instanceof Date
-              ? item.reply.createdAt.getTime()
-              : new Date(item.reply.createdAt).getTime()
-          }
-          const post = item as any
-          return post.createdAt instanceof Date
-            ? post.createdAt.getTime()
-            : new Date(post.createdAt).getTime()
-        }
-        setNewestPostTimestamp(Math.max(...existingPosts.map(getItemTimestamp)))
+        setNewestPostTimestamp(Math.max(...existingPosts.map(getFeedItemTimestamp)))
         setPendingNewPosts([])
         // Restore scroll position after a short delay to let content render
         const savedScrollPos = scrollPositions[activeTab]

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -136,8 +136,8 @@ function FeedPage() {
             }
           } else {
             setFollowingPosts(cached, user?.identityId || null)
-            // For following, we can't restore cursor from cache, so set hasMore based on length
-            setFollowingPagination(null, cached.length >= 20)
+            // Cursor can't be restored from cache; disable Load More since we have no cursor
+            setFollowingPagination(null, false)
           }
           setIsLoading(false)
           // Enrich cached posts (needed after back navigation when enrichment state is reset)

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -139,6 +139,22 @@ function FeedPage() {
             // Cursor can't be restored from cache; disable Load More since we have no cursor
             setFollowingPagination(null, false)
           }
+          // Set newestPostTimestamp so auto-refresh interval works after back navigation
+          if (cached.length > 0) {
+            const getItemTimestamp = (item: FeedItem): number => {
+              if (isFeedReplyContext(item)) {
+                return item.reply.createdAt instanceof Date
+                  ? item.reply.createdAt.getTime()
+                  : new Date(item.reply.createdAt).getTime()
+              }
+              const post = item as any
+              return post.createdAt instanceof Date
+                ? post.createdAt.getTime()
+                : new Date(post.createdAt).getTime()
+            }
+            setNewestPostTimestamp(Math.max(...cached.map(getItemTimestamp)))
+            setPendingNewPosts([])
+          }
           setIsLoading(false)
           // Enrich cached posts (needed after back navigation when enrichment state is reset)
           // Blocked users will be filtered via enrichmentState.blockStatus in render
@@ -973,6 +989,20 @@ function FeedPage() {
         )
         enrichProgressively(postsToEnrich)
         lastEnrichmentUserIdRef.current = user?.identityId
+        // Set newestPostTimestamp so auto-refresh interval works after back navigation
+        const getItemTimestamp = (item: FeedItem): number => {
+          if (isFeedReplyContext(item)) {
+            return item.reply.createdAt instanceof Date
+              ? item.reply.createdAt.getTime()
+              : new Date(item.reply.createdAt).getTime()
+          }
+          const post = item as any
+          return post.createdAt instanceof Date
+            ? post.createdAt.getTime()
+            : new Date(post.createdAt).getTime()
+        }
+        setNewestPostTimestamp(Math.max(...existingPosts.map(getItemTimestamp)))
+        setPendingNewPosts([])
         // Restore scroll position after a short delay to let content render
         const savedScrollPos = scrollPositions[activeTab]
         if (savedScrollPos > 0) {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -243,15 +243,21 @@ export const useFeedStore = create<FeedState>((set) => ({
 
   appendForYouPosts: (posts) =>
     set((state) => {
-      const existingIds = new Set((state.forYouPosts || []).map(getFeedItemId))
-      const newPosts = posts.filter((p) => !existingIds.has(getFeedItemId(p)))
+      const existingIds = new Set((state.forYouPosts || []).map(getFeedItemId).filter(Boolean))
+      const newPosts = posts.filter((p) => {
+        const id = getFeedItemId(p)
+        return !id || !existingIds.has(id)
+      })
       return { forYouPosts: [...(state.forYouPosts || []), ...newPosts] }
     }),
 
   appendFollowingPosts: (posts) =>
     set((state) => {
-      const existingIds = new Set((state.followingPosts || []).map(getFeedItemId))
-      const newPosts = posts.filter((p) => !existingIds.has(getFeedItemId(p)))
+      const existingIds = new Set((state.followingPosts || []).map(getFeedItemId).filter(Boolean))
+      const newPosts = posts.filter((p) => {
+        const id = getFeedItemId(p)
+        return !id || !existingIds.has(id)
+      })
       return { followingPosts: [...(state.followingPosts || []), ...newPosts] }
     }),
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -194,8 +194,8 @@ export interface FeedPagination {
 
 interface FeedState {
   // Feed posts by tab
-  forYouPosts: any[] | null
-  followingPosts: any[] | null
+  forYouPosts: FeedItem[] | null
+  followingPosts: FeedItem[] | null
   // Pagination state
   pagination: FeedPagination
   // Scroll position by tab
@@ -206,10 +206,10 @@ interface FeedState {
   // Track which user's following feed is cached
   followingUserId: string | null
   // Actions
-  setForYouPosts: (posts: any[] | null) => void
-  setFollowingPosts: (posts: any[] | null, userId: string | null) => void
-  appendForYouPosts: (posts: any[]) => void
-  appendFollowingPosts: (posts: any[]) => void
+  setForYouPosts: (posts: FeedItem[] | null) => void
+  setFollowingPosts: (posts: FeedItem[] | null, userId: string | null) => void
+  appendForYouPosts: (posts: FeedItem[]) => void
+  appendFollowingPosts: (posts: FeedItem[]) => void
   setForYouPagination: (lastPostId: string | null, hasMore: boolean) => void
   setFollowingPagination: (nextWindow: { start: Date; end: Date; windowHours: number } | null, hasMore: boolean) => void
   setScrollPosition: (tab: 'forYou' | 'following', position: number) => void

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { User, Post } from './types'
+import { User, Post, FeedItem, isFeedReplyContext } from './types'
 import { mockCurrentUser } from './mock-data'
 import { ProgressiveEnrichment } from '@/components/post/post-card'
 
@@ -176,6 +176,10 @@ export const useSettingsStore = create<SettingsState>()(
   )
 )
 
+// Helper to get a stable ID from a feed item (handles both Post and FeedReplyContext)
+const getFeedItemId = (item: FeedItem): string | undefined =>
+  isFeedReplyContext(item) ? item.reply.id : item.id
+
 // Feed state store - persists feed data across navigation
 export interface FeedPagination {
   forYou: {
@@ -239,15 +243,15 @@ export const useFeedStore = create<FeedState>((set) => ({
 
   appendForYouPosts: (posts) =>
     set((state) => {
-      const existingIds = new Set((state.forYouPosts || []).map((p: any) => p.id))
-      const newPosts = posts.filter((p: any) => !existingIds.has(p.id))
+      const existingIds = new Set((state.forYouPosts || []).map(getFeedItemId))
+      const newPosts = posts.filter((p) => !existingIds.has(getFeedItemId(p)))
       return { forYouPosts: [...(state.forYouPosts || []), ...newPosts] }
     }),
 
   appendFollowingPosts: (posts) =>
     set((state) => {
-      const existingIds = new Set((state.followingPosts || []).map((p: any) => p.id))
-      const newPosts = posts.filter((p: any) => !existingIds.has(p.id))
+      const existingIds = new Set((state.followingPosts || []).map(getFeedItemId))
+      const newPosts = posts.filter((p) => !existingIds.has(getFeedItemId(p)))
       return { followingPosts: [...(state.followingPosts || []), ...newPosts] }
     }),
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -234,6 +234,13 @@ export function getFeedItemTimestamp(item: FeedItem): number {
   return date instanceof Date ? date.getTime() : new Date(date).getTime()
 }
 
+// Helper to extract all posts from feed items for enrichment
+export function extractPostsFromFeedItems(items: FeedItem[]): Post[] {
+  return items.flatMap(item =>
+    isFeedReplyContext(item) ? [item.originalPost, item.reply] : [item]
+  )
+}
+
 // DPNS Multi-Username Registration Types
 export type UsernameStatus = 'pending' | 'checking' | 'available' | 'contested' | 'taken' | 'invalid'
 export type RegistrationStep = 'username-entry' | 'checking' | 'review' | 'registering' | 'complete'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -228,6 +228,12 @@ export function isFeedReplyContext(item: FeedItem): item is FeedReplyContext {
   return 'type' in item && item.type === 'reply_context'
 }
 
+// Helper to get a timestamp from a feed item (handles both Post and FeedReplyContext)
+export function getFeedItemTimestamp(item: FeedItem): number {
+  const date = isFeedReplyContext(item) ? item.reply.createdAt : item.createdAt
+  return date instanceof Date ? date.getTime() : new Date(date).getTime()
+}
+
 // DPNS Multi-Username Registration Types
 export type UsernameStatus = 'pending' | 'checking' | 'available' | 'contested' | 'taken' | 'invalid'
 export type RegistrationStep = 'username-entry' | 'checking' | 'review' | 'registering' | 'complete'


### PR DESCRIPTION
When navigating from feed to a post detail and back, the feed state was being lost because the component remounted and cleared all state.

Changes:
- Add useFeedStore Zustand store to persist feed posts, pagination cursors, and scroll positions across navigation
- Update feed page to use store state instead of local React state
- Distinguish between tab switches (load fresh or use cached data) vs initial mount/back navigation (restore from store if available)
- Track and restore scroll position when returning to feed
- Only clear feed state on explicit refresh or when user changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent per‑tab feed state: cached posts, independent pagination, and preserved scroll positions with automatic restoration and re‑enrichment on tab switch or return.

* **Refactor**
  * Centralized feed state store; UI now tracks local loading and error states separately for clearer interactions.

* **Bug Fixes**
  * Improved deduplication, more reliable pagination, reload/retry feedback, and graceful fallbacks on load failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->