### PR TITLE
Fix infinite loop in followers and following pages

### DIFF
--- a/app/followers/page.tsx
+++ b/app/followers/page.tsx
@@ -38,6 +38,8 @@ function FollowersPage() {
   const { user } = useAuth()
   const { requireAuth } = useRequireAuth()
   const followersState = useAsyncState<Follower[]>(null)
+  // Extract stable setter functions to avoid infinite loop in useCallback dependencies
+  const { setLoading, setError, setData } = followersState
   const [actionInProgress, setActionInProgress] = useState<Set<string>>(new Set())
   const [targetUserName, setTargetUserName] = useState<string | null>(null)
 
@@ -47,8 +49,6 @@ function FollowersPage() {
 
   // Load followers list
   const loadFollowers = useCallback(async (forceRefresh: boolean = false) => {
-    const { setLoading, setError, setData } = followersState
-
     setLoading(true)
     setError(null)
 
@@ -205,7 +205,7 @@ function FollowersPage() {
     } finally {
       setLoading(false)
     }
-  }, [followersState, isOwnProfile, user?.identityId, targetUserId])
+  }, [setLoading, setError, setData, isOwnProfile, user?.identityId, targetUserId])
 
   useEffect(() => {
     // Load when we have a user (for own profile) or a targetUserId (for viewing others)

--- a/app/following/page.tsx
+++ b/app/following/page.tsx
@@ -57,6 +57,8 @@ function FollowingPage() {
   const { user } = useAuth()
   const { requireAuth } = useRequireAuth()
   const followingState = useAsyncState<FollowingUser[]>(null)
+  // Extract stable setter functions to avoid infinite loop in useCallback dependencies
+  const { setLoading, setError, setData } = followingState
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState<FollowingUser[]>([])
   const [isSearching, setIsSearching] = useState(false)
@@ -70,8 +72,6 @@ function FollowingPage() {
 
   // Load following list
   const loadFollowing = useCallback(async (forceRefresh: boolean = false) => {
-    const { setLoading, setError, setData } = followingState
-
     setLoading(true)
     setError(null)
 
@@ -219,7 +219,7 @@ function FollowingPage() {
     } finally {
       setLoading(false)
     }
-  }, [followingState, user?.identityId, targetUserId])
+  }, [setLoading, setError, setData, user?.identityId, targetUserId])
 
   useEffect(() => {
     // Load when we have a user (for own profile) or a targetUserId (for viewing others)


### PR DESCRIPTION
The useAsyncState hook returns a new object every time state changes, even though the setter functions (setLoading, setError, setData) are stable. By including followersState/followingState in the useCallback dependencies, the callback was being recreated on every state change, which triggered the useEffect, causing an infinite loop.

Fix: Extract the stable setter functions and use those in the dependency array instead of the whole state object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized state management to improve application stability and reduce unnecessary re-rendering when viewing follower and following lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->