### PR TITLE
Fix gap between testnet banner and page content

### DIFF
--- a/components/ui/development-banner.tsx
+++ b/components/ui/development-banner.tsx
@@ -1,6 +1,6 @@
 export function DevelopmentBanner() {
   return (
-    <div className="bg-amber-500 text-black px-4 py-2 text-sm fixed top-0 left-0 right-0 z-50">
+    <div className="bg-amber-500 text-black px-4 py-2.5 text-sm fixed top-0 left-0 right-0 z-50">
       <div className="max-w-7xl mx-auto text-center">
         <span className="font-bold">TESTNET</span>
         {' '}


### PR DESCRIPTION
Increase banner vertical padding from py-2 to py-2.5 to make the banner height (~40px) consistent with the spacer in layout.tsx and the sticky header positioning (top-[40px]) used across all pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined vertical spacing on the development banner for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->