### PR TITLE
Fix profile creation timeout error handling

### DIFF
--- a/app/profile/create/page.tsx
+++ b/app/profile/create/page.tsx
@@ -15,6 +15,7 @@ import type { SocialLink } from '@/lib/types'
 import { PaymentUriInput } from '@/components/profile/payment-uri-input'
 import { SocialLinksInput } from '@/components/profile/social-links-input'
 import type { MigrationStatus } from '@/lib/services/profile-migration-service'
+import { extractErrorMessage, isTimeoutError } from '@/lib/error-utils'
 import {
   unifiedProfileService,
   DICEBEAR_STYLES,
@@ -162,7 +163,7 @@ function CreateProfilePage() {
     } catch (error: unknown) {
       console.error('Failed to create profile:', error)
 
-      const errorMessage = error instanceof Error ? error.message : String(error)
+      const errorMessage = extractErrorMessage(error)
 
       // Check if it's a duplicate profile error
       if (errorMessage.includes('duplicate unique properties') ||
@@ -175,12 +176,7 @@ function CreateProfilePage() {
       }
 
       // Check if it's a timeout error - the profile might have been created successfully
-      const isTimeoutError = errorMessage.toLowerCase().includes('timeout') ||
-                            errorMessage.toLowerCase().includes('timed out') ||
-                            errorMessage.toLowerCase().includes('deadline expired') ||
-                            errorMessage.toLowerCase().includes('deadline_exceeded')
-
-      if (isTimeoutError && user) {
+      if (isTimeoutError(error) && user) {
         toast.loading('Request timed out. Checking if profile was created...', { duration: 3000 })
 
         // Wait a moment for the network to propagate, then check if profile exists


### PR DESCRIPTION
When waitForStateTransitionResult times out during profile creation, the error message was showing unhelpful text like "[object Object]".

Now the code:
1. Detects timeout errors by checking error message patterns
2. Shows a loading message while checking if profile was created
3. Queries for the profile after a brief delay
4. If profile exists, treats it as success and redirects
5. If profile doesn't exist, shows a clear "Request timed out" message

This handles the common case where the DAPI timeout occurs but the profile was actually created successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved profile creation error handling with clearer, more actionable messages.
  * Added timeout-aware recovery: on timeouts the app checks if a profile was created and recovers automatically when possible.
  * Better handling for duplicate-profile cases to avoid unnecessary failures and preserve existing redirect flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->