### PR TITLE
Strip URLs from post content when link previews are enabled

### DIFF
--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -6,7 +6,7 @@ import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { HashtagValidationStatus } from '@/hooks/use-hashtag-validation'
 import { MentionValidationStatus } from '@/hooks/use-mention-validation'
 import { LinkPreview, LinkPreviewSkeleton, LinkPreviewEnablePrompt } from './link-preview'
-import { useLinkPreview, extractFirstUrl } from '@/hooks/use-link-preview'
+import { useLinkPreview, extractFirstUrl, stripTrailingPunctuation } from '@/hooks/use-link-preview'
 import { useSettingsStore } from '@/lib/store'
 import { cashtagDisplayToStorage, normalizeDpnsUsername } from '@/lib/post-helpers'
 import { MentionLink } from './mention-link'
@@ -220,13 +220,14 @@ export function PostContent({
       const href = part.value.startsWith('www.')
         ? `https://${part.value}`
         : part.value
-      const cleanHref = href.replace(/[.,;:!?)]+$/, '')
+      // Use stripTrailingPunctuation for cleanHref to match extractFirstUrl's normalization
+      const cleanHref = stripTrailingPunctuation(href)
       const cleanDisplay = part.value.replace(/[.,;:!?)]+$/, '')
       const trailingPunctuation = part.value.slice(cleanDisplay.length)
 
-      // If link previews are enabled and this URL is being previewed, strip it from content
-      // Keep only trailing punctuation (if any)
-      if (linkPreviews && firstUrl && cleanHref === firstUrl) {
+      // If link previews are enabled and this URL is being previewed (loading or loaded), strip it from content
+      // Keep only trailing punctuation (if any). If preview fetch fails, the raw URL remains visible.
+      if (linkPreviews && firstUrl && cleanHref === firstUrl && (previewLoading || previewData)) {
         return trailingPunctuation ? <Fragment key={key}>{trailingPunctuation}</Fragment> : null
       }
 

--- a/hooks/use-link-preview.ts
+++ b/hooks/use-link-preview.ts
@@ -360,7 +360,7 @@ export function useLinkPreview(
  * Strip trailing punctuation while preserving balanced parentheses
  * This handles URLs like https://en.wikipedia.org/wiki/Foo_(bar)
  */
-function stripTrailingPunctuation(url: string): string {
+export function stripTrailingPunctuation(url: string): string {
   // Characters to strip from end (excluding closing paren which needs balance check)
   const punctuation = /[.,;:!?]+$/
 


### PR DESCRIPTION
When the link previews setting is enabled and a URL is being previewed, the URL is now hidden from the post content text to avoid redundancy since the preview card already shows the link information. Trailing punctuation after the URL is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link-preview rendering: when link previews are enabled, the first detected URL in content is removed from inline text so it no longer appears twice; only any trailing punctuation is shown alongside the preview.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->