### PR TITLE
Add language selection to post composer

### DIFF
--- a/lib/dash-platform-client.ts
+++ b/lib/dash-platform-client.ts
@@ -70,6 +70,7 @@ export class DashPlatformClient {
     quotedPostId?: string
     mediaUrl?: string
     primaryHashtag?: string
+    language?: string
   }) {
     // Get identity ID from instance or auth context
     let identityId = this.identityId
@@ -150,8 +151,8 @@ export class DashPlatformClient {
         postData.primaryHashtag = options.primaryHashtag.replace('#', '')
       }
       
-      // Add language (defaults to 'en' in the contract, but let's be explicit)
-      postData.language = 'en'
+      // Add language (defaults to 'en' if not specified)
+      postData.language = options?.language || 'en'
       
       console.log('Creating post with data:', postData)
       


### PR DESCRIPTION
Users can now select the language of their post from a dropdown in the compose modal footer. Supports 20 common languages with ISO 639-1 codes.

- Added LanguageSelector component with dropdown UI
- Updated DashPlatformClient.createPost to accept language parameter
- Language defaults to English and resets when modal closes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added language selection for posts. A new language selector dropdown in the compose modal allows users to choose from supported languages with keyboard navigation support.
  * Posts now include language metadata upon creation, with English set as the default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->