### PR TITLE
Fix high CPU usage in compose modal by removing backdrop-blur

### DIFF
--- a/components/compose/compose-modal.tsx
+++ b/components/compose/compose-modal.tsx
@@ -759,7 +759,7 @@ export function ComposeModal() {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-start justify-center pt-12 sm:pt-20 px-4 overflow-y-auto pb-12"
+                className="fixed inset-0 bg-black/60 z-50 flex items-start justify-center pt-12 sm:pt-20 px-4 overflow-y-auto pb-12"
               >
                 <Dialog.Content asChild>
                   <motion.div


### PR DESCRIPTION
The backdrop-blur-sm CSS filter on the modal overlay was causing significant CPU usage, especially on low-powered machines. This filter forces the browser to continuously blur everything behind the element, which is expensive. The nested modal structure made it worse since every keystroke triggered re-renders that could recalculate the blur.

The bg-black/60 background provides sufficient visual separation without the performance cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced backdrop blur effect on the compose modal overlay.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->