### PR TITLE
Add credit tip button to user profile page

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -37,6 +37,7 @@ import { PaymentSchemeIcon, getPaymentLabel, truncateAddress } from '@/component
 import { PaymentQRCodeDialog } from '@/components/ui/payment-qr-dialog'
 import { useBlock } from '@/hooks/use-block'
 import { useProgressiveEnrichment } from '@/hooks/use-progressive-enrichment'
+import { useTipModal } from '@/hooks/use-tip-modal'
 import { AtSymbolIcon } from '@heroicons/react/24/outline'
 import { mentionService } from '@/lib/services/mention-service'
 import { MENTION_CONTRACT_ID } from '@/lib/constants'
@@ -107,6 +108,9 @@ function UserProfileContent() {
 
   // Block state - only check if viewing another user's profile
   const { isBlocked: isBlockedByMe, isLoading: blockLoading, toggleBlock } = useBlock(userId || '')
+
+  // Tip modal
+  const { openForUser: openTipModal } = useTipModal()
 
   // Tab state for Posts/Mentions
   const [activeTab, setActiveTab] = useState<'posts' | 'mentions'>('posts')
@@ -671,6 +675,16 @@ function UserProfileContent() {
     setEditSocialLinks([])
   }
 
+  const handleTipUser = () => {
+    const authedUser = requireAuth('tip')
+    if (!authedUser || !userId) return
+    openTipModal({
+      id: userId,
+      displayName: profile?.displayName,
+      username: username || undefined,
+    })
+  }
+
   // Refresh DPNS usernames after registration
   const refreshUsernames = useCallback(async () => {
     if (!userId) return
@@ -895,6 +909,27 @@ function UserProfileContent() {
                     )
                   ) : (
                     <div className="flex gap-2">
+                      <Tooltip.Provider>
+                        <Tooltip.Root>
+                          <Tooltip.Trigger asChild>
+                            <button
+                              onClick={handleTipUser}
+                              aria-label={`Tip ${profile?.displayName || username || 'user'}`}
+                              className="p-2 rounded-full border border-gray-200 dark:border-gray-700 hover:bg-amber-50 dark:hover:bg-amber-950 hover:border-amber-300 dark:hover:border-amber-700 transition-colors group"
+                            >
+                              <CurrencyDollarIcon className="h-4 w-4 group-hover:text-amber-500" />
+                            </button>
+                          </Tooltip.Trigger>
+                          <Tooltip.Portal>
+                            <Tooltip.Content
+                              className="bg-gray-800 dark:bg-gray-700 text-white text-xs px-2 py-1 rounded"
+                              sideOffset={5}
+                            >
+                              Tip with credits
+                            </Tooltip.Content>
+                          </Tooltip.Portal>
+                        </Tooltip.Root>
+                      </Tooltip.Provider>
                       <Tooltip.Provider>
                         <Tooltip.Root>
                           <Tooltip.Trigger asChild>

--- a/hooks/use-tip-modal.ts
+++ b/hooks/use-tip-modal.ts
@@ -1,16 +1,27 @@
 import { create } from 'zustand'
 import { Post } from '@/lib/types'
 
+// Recipient data for user-only tipping (when no post is involved)
+export interface TipRecipient {
+  id: string
+  displayName?: string
+  username?: string
+}
+
 interface TipModalStore {
   isOpen: boolean
   post: Post | null
+  recipient: TipRecipient | null  // For user-only tipping
   open: (post: Post) => void
+  openForUser: (recipient: TipRecipient) => void  // Open modal to tip a user directly
   close: () => void
 }
 
 export const useTipModal = create<TipModalStore>((set) => ({
   isOpen: false,
   post: null,
-  open: (post) => set({ isOpen: true, post }),
-  close: () => set({ isOpen: false, post: null }),
+  recipient: null,
+  open: (post) => set({ isOpen: true, post, recipient: null }),
+  openForUser: (recipient) => set({ isOpen: true, post: null, recipient }),
+  close: () => set({ isOpen: false, post: null, recipient: null }),
 }))

--- a/lib/services/tip-service.ts
+++ b/lib/services/tip-service.ts
@@ -29,10 +29,10 @@ export const MIN_TIP_CREDITS = 100_000_000; // 0.001 DASH minimum
 
 class TipService {
   /**
-   * Send a tip (credit transfer) to another user and create a tip post
+   * Send a tip (credit transfer) to another user and optionally create a tip post
    * @param senderId - The sender's identity ID
-   * @param recipientId - The recipient's identity ID (post author)
-   * @param postId - The post being tipped
+   * @param recipientId - The recipient's identity ID (post author or user being tipped)
+   * @param postId - The post being tipped (optional - when null, no tip post is created)
    * @param amountCredits - Amount in credits
    * @param transferKeyWif - The sender's transfer private key in WIF format
    * @param message - Optional tip message
@@ -41,7 +41,7 @@ class TipService {
   async sendTip(
     senderId: string,
     recipientId: string,
-    postId: string,
+    postId: string | null,
     amountCredits: number,
     transferKeyWif: string,
     message?: string,
@@ -170,9 +170,11 @@ class TipService {
 
       console.log('Tip transfer result:', result);
 
-      // Create tip post as a reply to the tipped post
+      // Create tip post as a reply to the tipped post (only if postId provided)
       // TODO: Once SDK returns transition ID, pass it for on-chain verification
-      await this.createTipPost(senderId, postId, amountCredits, message);
+      if (postId) {
+        await this.createTipPost(senderId, postId, amountCredits, message);
+      }
 
       return {
         success: true,
@@ -193,7 +195,9 @@ class TipService {
         identityService.clearCache(senderId);
 
         // Create tip post (amount is known even if confirmation timed out)
-        await this.createTipPost(senderId, postId, amountCredits, message);
+        if (postId) {
+          await this.createTipPost(senderId, postId, amountCredits, message);
+        }
 
         return {
           success: true,


### PR DESCRIPTION
- Extend useTipModal hook to support user-only tipping via openForUser()
- Make postId optional in tip service for direct user-to-user transfers
- Update TipModal to handle both post tips and direct user tips
- Add credit tip button alongside message/follow buttons on profile page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now tip each other directly from profiles using the new "Tip with credits" button. The tipping system has been expanded to support both post-based and direct user-to-user credit transfers, providing greater flexibility for user interactions and payments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->