### PR TITLE
Fix user page to use consistent DPNS primary username selection

### DIFF
--- a/app/followers/page.tsx
+++ b/app/followers/page.tsx
@@ -116,10 +116,15 @@ function FollowersPage() {
             return { id, username: null }
           }
         })),
-        // Fetch all usernames for each identity
+        // Fetch all usernames for each identity (sorted consistently)
         Promise.all(identityIds.map(async (id) => {
           try {
             const usernames = await dpnsService.getAllUsernames(id)
+            if (usernames.length > 1) {
+              // Sort usernames: contested first, then shortest, then alphabetically
+              const sortedUsernames = await dpnsService.sortUsernamesByContested(usernames)
+              return { id, usernames: sortedUsernames }
+            }
             return { id, usernames }
           } catch (error) {
             console.error(`Failed to get all usernames for ${id}:`, error)

--- a/app/following/page.tsx
+++ b/app/following/page.tsx
@@ -129,10 +129,15 @@ function FollowingPage() {
       
       // Batch fetch all usernames, best usernames, profiles, and follower/following counts
       const [allUsernamesData, bestUsernamesMap, profiles, followerCounts, followingCounts] = await Promise.all([
-        // Fetch all usernames for each identity (for "Also known as" feature)
+        // Fetch all usernames for each identity (for "Also known as" feature), sorted consistently
         Promise.all(identityIds.map(async (id) => {
           try {
             const usernames = await dpnsService.getAllUsernames(id)
+            if (usernames.length > 1) {
+              // Sort usernames: contested first, then shortest, then alphabetically
+              const sortedUsernames = await dpnsService.sortUsernamesByContested(usernames)
+              return { id, usernames: sortedUsernames }
+            }
             return { id, usernames }
           } catch (error) {
             console.error(`Failed to get all usernames for ${id}:`, error)

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -127,7 +127,14 @@ function SettingsPage() {
       try {
         const { dpnsService } = await import('@/lib/services/dpns-service')
         const usernames = await dpnsService.getAllUsernames(user.identityId)
-        setDpnsUsernames(usernames)
+        if (usernames.length > 0) {
+          // Sort usernames: contested first, then shortest, then alphabetically
+          // This matches the selection logic used across the app
+          const sortedUsernames = await dpnsService.sortUsernamesByContested(usernames)
+          setDpnsUsernames(sortedUsernames)
+        } else {
+          setDpnsUsernames([])
+        }
       } catch (error) {
         console.error('Failed to fetch DPNS usernames:', error)
       }
@@ -141,9 +148,16 @@ function SettingsPage() {
     if (!user?.identityId) return
     try {
       const { dpnsService } = await import('@/lib/services/dpns-service')
-      dpnsService.clearCache(user.identityId)
+      // Clear cache to get fresh data (pass undefined for username, identityId second)
+      dpnsService.clearCache(undefined, user.identityId)
       const usernames = await dpnsService.getAllUsernames(user.identityId)
-      setDpnsUsernames(usernames)
+      if (usernames.length > 0) {
+        // Sort usernames: contested first, then shortest, then alphabetically
+        const sortedUsernames = await dpnsService.sortUsernamesByContested(usernames)
+        setDpnsUsernames(sortedUsernames)
+      } else {
+        setDpnsUsernames([])
+      }
     } catch (error) {
       console.error('Failed to refresh usernames:', error)
     }

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -679,12 +679,15 @@ function UserProfileContent() {
     if (!userId) return
     try {
       const { dpnsService } = await import('@/lib/services/dpns-service')
-      // Clear cache to get fresh data
-      dpnsService.clearCache(userId)
+      // Clear cache to get fresh data (pass undefined for username, userId for identityId)
+      dpnsService.clearCache(undefined, userId)
       const usernames = await dpnsService.getAllUsernames(userId)
       if (usernames.length > 0) {
-        setAllUsernames(usernames)
-        setUsername(usernames[0])
+        // Sort usernames: contested first, then shortest, then alphabetically
+        // This matches the selection logic used in loadProfileData and resolveUsernamesBatch
+        const sortedUsernames = await dpnsService.sortUsernamesByContested(usernames)
+        setAllUsernames(sortedUsernames)
+        setUsername(sortedUsernames[0])
         setHasDpns(true)
       } else {
         // No usernames found, reset state


### PR DESCRIPTION
User page was using getAllUsernames() and taking the first result directly, while other pages (posts, followers, following) use sortUsernamesByContested() to properly select the best username (contested first, then shortest, then alphabetically).

This fix applies the same sorting logic on the user page to ensure consistent primary username selection across the entire app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More consistent primary DPNS username selection using enhanced sorting that prioritizes contested names, then shortest, then alphabetical — applied across profiles, followers, following and settings.
  * Username updates now propagate reliably to posts and profile state.
* **Bug Fixes**
  * Safer handling when no DPNS names are found: related state resets and errors are logged without affecting posts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->