### PR TITLE
Fix error when viewing Following tab as non-logged-in user

### DIFF
--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -96,6 +96,14 @@ function FeedPage() {
     setError(null)
 
     try {
+      // Don't load posts on Following tab if user is not logged in
+      // (the login prompt is shown instead, and posts won't be displayed)
+      if (activeTab === 'following' && !user?.identityId) {
+        console.log('Feed: Skipping Following feed load - user not logged in')
+        setLoading(false)
+        return
+      }
+
       console.log(`Feed: Loading ${activeTab} posts from Dash Platform...`, isPaginating ? '(paginating)' : '')
 
       const cacheKey = activeTab === 'following'

--- a/hooks/use-progressive-enrichment.ts
+++ b/hooks/use-progressive-enrichment.ts
@@ -124,8 +124,8 @@ export function useProgressiveEnrichment(
     // Check if this request is still valid
     const isValid = () => enrichmentIdRef.current === requestId
 
-    // Extract IDs
-    const postIds = posts.map(p => p.id)
+    // Extract IDs (deduplicate to prevent "duplicate values for In query" errors)
+    const postIds = Array.from(new Set(posts.map(p => p.id).filter(Boolean)))
     const authorIds = Array.from(new Set(posts.map(p => p.author.id).filter(Boolean)))
 
     // Collect parent post IDs for replies


### PR DESCRIPTION
When a non-logged-in user navigates to the Following tab, the loadPosts function was still being called and attempting to enrich posts that would never be displayed (the login prompt is shown instead). This caused unnecessary queries and potential "duplicate values for In query" errors.

Changes:
- Add early return in loadPosts when on Following tab without user
- Deduplicate postIds in useProgressiveEnrichment as defensive measure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the Following feed attempted to load for unauthenticated users, preventing unnecessary network calls when not signed in.
  * Enhanced data query stability by removing duplicate and invalid post references during batch operations, reducing potential errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->