### PR TITLE
feat: display emoji-only posts with larger text

### DIFF
--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -20,16 +20,14 @@ function isEmojiOnly(text: string): boolean {
   const trimmed = text.trim()
   if (trimmed.length === 0) return false
 
-  // Match emoji characters including:
-  // - Basic emojis and presentation symbols
-  // - Skin tone modifiers
-  // - ZWJ sequences (family, profession emojis)
-  // - Flag emojis (regional indicators)
-  // - Variation selectors
-  // Note: \p{Emoji} includes digits 0-9, so we exclude those explicitly
+  // Match complete emoji sequences only (excludes digits/symbols that \p{Emoji} includes):
+  // - Base: \p{Extended_Pictographic} (actual pictorial emojis)
+  // - Optional: skin tone modifier or variation selector
+  // - Optional: ZWJ-linked sequences (family, profession emojis)
+  // - Only whitespace allowed between emoji sequences
   // Using RegExp constructor to avoid TS1501 error with es5 target
   const emojiRegex = new RegExp(
-    '^(?:[\\p{Emoji_Presentation}\\p{Extended_Pictographic}]|\\p{Emoji}\\uFE0F)[\\p{Emoji}\\p{Emoji_Modifier}\\p{Emoji_Component}\\uFE0F\\u200D\\s]*$',
+    '^(?:\\p{Extended_Pictographic}(?:\\p{Emoji_Modifier}|\\uFE0F)?(?:\\u200D\\p{Extended_Pictographic}(?:\\p{Emoji_Modifier}|\\uFE0F)?)*\\s*)+$',
     'u'
   )
   return emojiRegex.test(trimmed)


### PR DESCRIPTION
Posts containing only emojis now render at 4xl size for better visual emphasis, matching behavior in messaging apps like iMessage and WhatsApp.

Preview:
<img width="238" height="311" alt="image" src="https://github.com/user-attachments/assets/fe4b09e2-1510-439a-acd8-cb17c9e00afe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts that contain only emoji are now rendered with larger, tighter typography so emoji-only content appears more prominent and reads better across layouts and screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->