### PR TITLE
fix: respect potato mode in emoji picker

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,4 +51,13 @@
   .safe-area-inset-top {
     padding-top: env(safe-area-inset-top, 0);
   }
+
+  /* Disable all backdrop blur effects inside emoji picker when potato mode is enabled */
+  .potato-mode,
+  .potato-mode *,
+  .potato-mode *::before,
+  .potato-mode *::after {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
 }

--- a/components/compose/emoji-picker.tsx
+++ b/components/compose/emoji-picker.tsx
@@ -5,6 +5,7 @@ import * as Popover from '@radix-ui/react-popover'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
 import { useTheme } from 'next-themes'
+import { useSettingsStore } from '@/lib/store'
 
 interface EmojiData {
   native: string
@@ -20,6 +21,7 @@ interface EmojiPickerProps {
 export function EmojiPicker({ onEmojiSelect, disabled = false }: EmojiPickerProps) {
   const [open, setOpen] = useState(false)
   const { resolvedTheme } = useTheme()
+  const potatoMode = useSettingsStore((s) => s.potatoMode)
 
   const handleEmojiSelect = useCallback(
     (emoji: EmojiData) => {
@@ -54,6 +56,7 @@ export function EmojiPicker({ onEmojiSelect, disabled = false }: EmojiPickerProp
           <div
             onWheel={(e) => e.stopPropagation()}
             onTouchMove={(e) => e.stopPropagation()}
+            className={potatoMode ? 'potato-mode' : ''}
           >
             <Picker
               data={data}


### PR DESCRIPTION
Add potato mode support to the emoji picker component to disable backdrop blur effects when potato mode is enabled for better performance on older devices.