### PR TITLE
Fix reply profile enrichment on post detail page

### DIFF
--- a/hooks/use-post-detail.ts
+++ b/hooks/use-post-detail.ts
@@ -211,7 +211,7 @@ export function usePostDetail({
       }
 
       // Load direct replies (now from reply-service)
-      const repliesResult = await replyService.getReplies(postId, { skipEnrichment: true })
+      const repliesResult = await replyService.getReplies(postId)
       const directReplies = repliesResult.documents
 
       // Build author's thread chain recursively
@@ -223,7 +223,7 @@ export function usePostDetail({
       // Helper to recursively fetch author's thread continuation
       const fetchAuthorThreadContinuation = async (parentIds: string[]): Promise<Reply[]> => {
         if (parentIds.length === 0) return []
-        const nestedMap = await replyService.getNestedReplies(parentIds, { skipEnrichment: true })
+        const nestedMap = await replyService.getNestedReplies(parentIds)
         const authorContinuations: Reply[] = []
 
         nestedMap.forEach((nested, parentId) => {
@@ -270,7 +270,7 @@ export function usePostDetail({
       const allIdsForNested = Array.from(new Set([...allDirectReplyIds, ...allThreadReplyIds]))
 
       const nestedRepliesMap = allIdsForNested.length > 0
-        ? await replyService.getNestedReplies(allIdsForNested, { skipEnrichment: true })
+        ? await replyService.getNestedReplies(allIdsForNested)
         : new Map<string, Reply[]>()
 
       // Build threaded reply tree
@@ -299,7 +299,7 @@ export function usePostDetail({
       // Set initial state immediately (with placeholder data)
       setState({ post: loadedPost, replies, replyThreads })
 
-      // Enrich the main post only (replies are already enriched by replyService)
+      // Enrich the main post (replies are enriched by replyService during loading)
       await enrich([loadedPost])
 
     } catch (err) {


### PR DESCRIPTION
Replies were being loaded with skipEnrichment: true but never enriched
afterward, causing DPNS usernames and profile data to be missing from
replies on the post page. Removed skipEnrichment flag to allow
replyService to properly enrich author data during loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replies now load with complete data enrichment by default, ensuring consistent information across all reply types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->