### PR TITLE
Fix reply deletion using wrong document type

### DIFF
--- a/components/post/reply-thread.tsx
+++ b/components/post/reply-thread.tsx
@@ -7,6 +7,7 @@ import { PostCard } from './post-card'
 /**
  * Convert a Reply to a Post-like object for PostCard rendering.
  * This is a temporary adapter until PostCard is updated to handle both types.
+ * Preserves parentId/parentOwnerId so PostCard can detect replies for deletion.
  */
 function replyToPostLike(reply: Reply): Post {
   return {
@@ -26,6 +27,8 @@ function replyToPostLike(reply: Reply): Post {
     encryptedContent: reply.encryptedContent,
     epoch: reply.epoch,
     nonce: reply.nonce,
+    parentId: reply.parentId,
+    parentOwnerId: reply.parentOwnerId,
   }
 }
 

--- a/lib/services/reply-service.ts
+++ b/lib/services/reply-service.ts
@@ -169,6 +169,28 @@ class ReplyService extends BaseDocumentService<Reply> {
   }
 
   /**
+   * Delete a reply by its ID.
+   * Only the reply owner can delete their own replies.
+   */
+  async deleteReply(replyId: string, ownerId: string): Promise<boolean> {
+    try {
+      const { stateTransitionService } = await import('./state-transition-service');
+
+      const result = await stateTransitionService.deleteDocument(
+        this.contractId,
+        this.documentType,
+        replyId,
+        ownerId
+      );
+
+      return result.success;
+    } catch (error) {
+      console.error('Error deleting reply:', error);
+      return false;
+    }
+  }
+
+  /**
    * Create a reply to a post or another reply
    *
    * @param ownerId - Identity ID of the reply author

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -55,6 +55,9 @@ export interface Post {
   _enrichment?: PostEnrichment  // Pre-fetched data to avoid N+1 queries
   repostedBy?: { id: string; username?: string; displayName?: string }  // If this is a repost, who reposted it
   repostTimestamp?: Date  // When the repost was created (for timeline sorting)
+  // Reply fields (present when this Post object represents a Reply for display)
+  parentId?: string        // ID of post or reply being replied to (only on replies)
+  parentOwnerId?: string   // Owner of parent (only on replies)
   // Private feed fields (present when post is encrypted)
   encryptedContent?: Uint8Array  // XChaCha20-Poly1305 ciphertext
   epoch?: number                 // Revocation epoch at post creation


### PR DESCRIPTION
Replies were being deleted using postService.deletePost() which uses document type 'post', but replies are stored as document type 'reply' in the contract. This caused deletion to fail silently.

Changes:
- Add deleteReply() method to ReplyService using correct document type
- Add parentId/parentOwnerId fields to Post type to track reply status
- Update PostCard.handleDelete() to detect replies and use replyService
- Preserve parentId/parentOwnerId in replyToPostLike conversion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Posts and replies can now be deleted with context-specific confirmation messages to differentiate between the two content types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->