### PR TITLE
Fix reply detail page showing "Post not found"

### DIFF
--- a/hooks/use-post-detail.ts
+++ b/hooks/use-post-detail.ts
@@ -208,7 +208,17 @@ export function usePostDetail({
 
     try {
       // Load post (transformDocument returns post with defaults, no enrichment)
+      // Try post first, then reply if not found (replies are a separate document type)
       loadedPost = await postService.getPostById(postId, { skipEnrichment: true })
+
+      if (!loadedPost) {
+        // Not a post - check if it's a reply
+        const reply = await replyService.getReplyById(postId, { skipEnrichment: true })
+        if (reply) {
+          // Treat the reply as the main "post" for this detail view
+          loadedPost = reply as Post
+        }
+      }
 
       if (!isCurrent()) return
 


### PR DESCRIPTION
When clicking on a reply in a thread, the post detail page now correctly queries for both post and reply document types. Previously, it only queried the post document type, causing replies to show "Post not found".

https://claude.ai/code/session_01765BygkAoGuYALrdUECB4v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replies can now be accessed directly via their unique identifier. When accessing a reply, it displays as the main content, improving the ability to share and navigate to specific replies with the same ease as primary posts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->