### PR TITLE
Fix identifier fields passed as strings instead of byte arrays

### DIFF
--- a/lib/services/direct-message-service.ts
+++ b/lib/services/direct-message-service.ts
@@ -82,8 +82,8 @@ class DirectMessageService {
           'conversationInvite',
           senderId,
           {
-            // recipientId has contentMediaType identifier - pass as base58 string
-            recipientId,
+            // recipientId is an Identifier type - must be byte array
+            recipientId: Array.from(bs58.decode(recipientId)),
             // conversationId as array (10 bytes >= platform threshold)
             conversationId: conversationIdArray,
             // senderPubKey as array (33 bytes)

--- a/lib/services/private-feed-follower-service.ts
+++ b/lib/services/private-feed-follower-service.ts
@@ -123,8 +123,9 @@ class PrivateFeedFollowerService {
       }
 
       // 4. Create FollowRequest document
+      // targetId must be a byte array (Identifier type in contract)
       const documentData: Record<string, unknown> = {
-        targetId: ownerId,
+        targetId: Array.from(identifierToBytes(ownerId)),
       };
 
       // Include public key if provided (for hash160-only keys on identity)

--- a/lib/services/private-feed-service.ts
+++ b/lib/services/private-feed-service.ts
@@ -476,8 +476,9 @@ class PrivateFeedService {
       );
 
       // 11. Create PrivateFeedGrant document
+      // recipientId must be a byte array (Identifier type in contract)
       const documentData = {
-        recipientId: requesterId,
+        recipientId: Array.from(identifierToBytes(requesterId)),
         leafIndex,
         epoch: localEpoch,
         encryptedPayload: Array.from(encryptedPayload),


### PR DESCRIPTION
SDK v3 enforces strict schema validation for Identifier fields which must be byte arrays, not base58 strings. Fixed three locations:

- private-feed-follower-service.ts: targetId in FollowRequest
- private-feed-service.ts: recipientId in PrivateFeedGrant
- direct-message-service.ts: recipientId in conversationInvite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal identifier storage format in direct messaging and feed-related services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->