### PR TITLE
Fix identifier fields in queries to use byte arrays

### DIFF
--- a/lib/services/repost-service.ts
+++ b/lib/services/repost-service.ts
@@ -149,13 +149,15 @@ class RepostService {
   async getRepost(postId: string, ownerId: string): Promise<RepostDocument | null> {
     try {
       const sdk = await import('../services/evo-sdk-service').then(m => m.getEvoSdk());
+      // SDK v3 requires byte arrays for identifier fields in queries using quotedPostAndOwner index
+      const postIdBytes = stringToIdentifierBytes(postId);
 
       // Query using the quotedPostAndOwner index
       const response = await sdk.documents.query({
         dataContractId: this.contractId,
         documentTypeName: 'post',
         where: [
-          ['quotedPostId', '==', postId],
+          ['quotedPostId', '==', postIdBytes],
           ['$ownerId', '==', ownerId]
         ],
         limit: 1
@@ -184,6 +186,8 @@ class RepostService {
   async getPostReposts(postId: string): Promise<RepostDocument[]> {
     try {
       const sdk = await import('../services/evo-sdk-service').then(m => m.getEvoSdk());
+      // SDK v3 requires byte arrays for identifier fields in queries using quotedPostAndOwner index
+      const postIdBytes = stringToIdentifierBytes(postId);
 
       const { documents } = await paginateFetchAll(
         sdk,
@@ -191,7 +195,7 @@ class RepostService {
           dataContractId: this.contractId,
           documentTypeName: 'post',
           where: [
-            ['quotedPostId', '==', postId],
+            ['quotedPostId', '==', postIdBytes],
             ['$ownerId', '>', '']  // Need second field for index
           ],
           orderBy: [['quotedPostId', 'asc'], ['$ownerId', 'asc']]


### PR DESCRIPTION
SDK v3 requires Identifier fields in query where clauses to be passed as byte arrays (number[]), not base58 strings. This fixes the error: "field requirement unmet: expected system value to be 32 bytes long"

Services updated to use stringToIdentifierBytes() for query parameters:
- like-service: postId, postOwnerId queries
- repost-service: quotedPostId, quotedPostOwnerId queries
- post-service: quotedPostId queries (also fixed getQuotePosts to use index)
- follow-service: followingId queries
- bookmark-service: postId queries
- block-service: blockedId queries
- reply-service: parentId, parentOwnerId queries
- mention-service: postId, mentionedUserId queries
- hashtag-service: postId queries
- notification-service: followingId queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized query performance for likes, posts, and reposts functionality through index-based lookups and improved data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->