### PR TITLE
Fix notifications page showing "No notifications yet" during loading

### DIFF
--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -98,6 +98,7 @@ function NotificationsPage() {
   // Store - polling is handled by Sidebar, we just display data
   const filter = useNotificationStore((s) => s.filter)
   const isLoading = useNotificationStore((s) => s.isLoading)
+  const hasFetchedOnce = useNotificationStore((s) => s.hasFetchedOnce)
   const setFilter = useNotificationStore((s) => s.setFilter)
   const markAsRead = useNotificationStore((s) => s.markAsRead)
   const markAllAsRead = useNotificationStore((s) => s.markAllAsRead)
@@ -215,7 +216,7 @@ function NotificationsPage() {
           </div>
         )}
 
-        {isLoading ? (
+        {isLoading || !hasFetchedOnce ? (
           <div className="p-8 text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto mb-4"></div>
             <p className="text-gray-500">Loading notifications...</p>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -132,6 +132,11 @@ export function Sidebar() {
 
       const store = useNotificationStore.getState()
 
+      // Set loading state for initial fetch
+      if (isInitial) {
+        store.setLoading(true)
+      }
+
       try {
         const readIds = store.getReadIdsSet()
         const result = isInitial
@@ -142,12 +147,18 @@ export function Sidebar() {
 
         if (isInitial) {
           store.setNotifications(result.notifications)
+          store.setHasFetchedOnce(true)
         } else if (result.notifications.length > 0) {
           store.addNotifications(result.notifications)
         }
         store.setLastFetchTimestamp(result.latestTimestamp)
       } catch (error) {
         console.error('Notification fetch error:', error)
+      } finally {
+        if (isInitial && !cancelled) {
+          store.setLoading(false)
+          store.setHasFetchedOnce(true)
+        }
       }
 
       if (!cancelled) {

--- a/lib/stores/notification-store.ts
+++ b/lib/stores/notification-store.ts
@@ -30,6 +30,7 @@ interface NotificationState {
 
   // Loading states
   isLoading: boolean;
+  hasFetchedOnce: boolean;
 
   // Read state (persisted)
   readIds: string[];
@@ -42,6 +43,7 @@ interface NotificationState {
   markAllAsRead: () => void;
   setLoading: (loading: boolean) => void;
   setLastFetchTimestamp: (timestamp: number) => void;
+  setHasFetchedOnce: (fetched: boolean) => void;
   clearNotifications: () => void;
 
   // Computed helpers
@@ -59,6 +61,7 @@ export const useNotificationStore = create<NotificationState>()(
       lastFetchTimestamp: 0,
       filter: 'all',
       isLoading: false,
+      hasFetchedOnce: false,
       readIds: [],
 
       // Actions
@@ -120,6 +123,8 @@ export const useNotificationStore = create<NotificationState>()(
       setLoading: (isLoading) => set({ isLoading }),
 
       setLastFetchTimestamp: (timestamp) => set({ lastFetchTimestamp: timestamp }),
+
+      setHasFetchedOnce: (fetched) => set({ hasFetchedOnce: fetched }),
 
       clearNotifications: () => set({
         notifications: [],


### PR DESCRIPTION
Added hasFetchedOnce state to notification store to properly track whether the initial notification fetch has completed. Now the notifications page shows a loading spinner until the first fetch completes, instead of incorrectly showing "No notifications yet" before we know.

https://claude.ai/code/session_01QfoA7S48C7jaXFHQk2mBJE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced notification loading behavior to properly display loading indicators during the initial data fetch, ensuring consistent user feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->