### PR TITLE
Fix private feed settings not updating follower count on approval

### DIFF
--- a/components/settings/private-feed-settings.tsx
+++ b/components/settings/private-feed-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '@/contexts/auth-context'
+import { usePrivateFeedRefreshStore } from '@/lib/stores/private-feed-refresh-store'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -29,6 +30,7 @@ interface PrivateFeedSettingsProps {
 export function PrivateFeedSettings({ openReset = false, onResetOpened }: PrivateFeedSettingsProps) {
   const { user } = useAuth()
   const { open: openEncryptionKeyModal } = useEncryptionKeyModal()
+  const refreshKey = usePrivateFeedRefreshStore((state) => state.refreshKey)
   const [isEnabled, setIsEnabled] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [isEnabling, setIsEnabling] = useState(false)
@@ -107,7 +109,7 @@ export function PrivateFeedSettings({ openReset = false, onResetOpened }: Privat
 
   useEffect(() => {
     checkPrivateFeedStatus().catch(err => console.error('Failed to check private feed status:', err))
-  }, [checkPrivateFeedStatus])
+  }, [checkPrivateFeedStatus, refreshKey])
 
   // Handle openReset prop - open reset dialog when directed from lost key flow
   useEffect(() => {


### PR DESCRIPTION
The PrivateFeedSettings component was not subscribing to the refreshKey from the private feed refresh store, causing the follower count and available slots to not update when a follower was approved. The PrivateFeedDashboard component correctly subscribed to refreshKey, which is why only the bottom section updated.

Added usePrivateFeedRefreshStore subscription and refreshKey dependency to the useEffect that fetches the private feed status.

https://claude.ai/code/session_013kCtTo3wgzPdPf2fWTRM6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed private feed status check to properly respond to refresh requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->