### PR TITLE
Fix image preview not showing in compose modal preview

### DIFF
--- a/components/compose/compose-modal.tsx
+++ b/components/compose/compose-modal.tsx
@@ -21,6 +21,7 @@ import { useRequireAuth } from '@/hooks/use-require-auth'
 import { usePlatformDetection } from '@/hooks/use-platform-detection'
 import { UserAvatar } from '@/components/ui/avatar-image'
 import { extractAllTags, extractMentions } from '@/lib/post-helpers'
+import { extractFirstUrl, isDirectImageUrl } from '@/hooks/use-link-preview'
 import { hashtagService } from '@/lib/services/hashtag-service'
 import { mentionService } from '@/lib/services/mention-service'
 import { extractErrorMessage, isTimeoutError, categorizeError } from '@/lib/error-utils'
@@ -388,13 +389,37 @@ function ThreadPostEditor({
 
           {/* Content area */}
           {showPreview || isPosted ? (
-            <div className={`min-h-[60px] whitespace-pre-wrap break-words ${
+            <div className={`min-h-[60px] ${
               isPosted
                 ? 'text-gray-600 dark:text-gray-400'
                 : 'text-gray-900 dark:text-gray-100'
             }`}>
               {post.content ? (
-                <MarkdownContent content={post.content} />
+                <>
+                  <div className="whitespace-pre-wrap break-words">
+                    <MarkdownContent content={post.content} />
+                  </div>
+                  {/* Image preview for direct image URLs */}
+                  {(() => {
+                    const firstUrl = extractFirstUrl(post.content)
+                    if (firstUrl && isDirectImageUrl(firstUrl)) {
+                      return (
+                        <div className="mt-3 rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={firstUrl}
+                            alt="Image preview"
+                            className="w-full max-h-[300px] object-contain bg-gray-100 dark:bg-gray-800"
+                            onError={(e) => {
+                              e.currentTarget.style.display = 'none'
+                            }}
+                          />
+                        </div>
+                      )
+                    }
+                    return null
+                  })()}
+                </>
               ) : (
                 <span className="text-gray-400 dark:text-gray-600 italic">
                   Nothing to preview


### PR DESCRIPTION
When composing a post with a direct image URL (e.g., https://example.com/image.jpg),
the preview mode now shows the image inline, matching the behavior after posting.

Previously, the compose preview only showed image URLs as clickable links while
the posted version showed them as inline images via LinkPreview.

https://claude.ai/code/session_01QS6hsm9agZ7diaU7Tp8waK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compose modal auto-detects the first direct image URL in post content and shows an inline image preview card with the source hostname footer.
  * The displayed post text removes the image URL while preserving remaining Markdown and styling.

* **Bug Fixes**
  * Image preview hides gracefully and shows a fallback message when loading fails; preview state resets when content changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->