### PR TITLE
Fix back button in notification settings to return to previous page

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -167,12 +167,7 @@ function SettingsPage() {
   }
 
   const handleBack = () => {
-    if (activeSection === 'main') {
-      router.back()
-    } else {
-      // Navigate to main settings (removes query param)
-      router.push('/settings')
-    }
+    router.back()
   }
 
   // TODO: Implement account deletion


### PR DESCRIPTION
The back button in settings subsections (like notifications) was always navigating to the main settings page instead of respecting browser history. This caused a poor UX when accessing notification settings from the notifications page - pressing back would go to main settings instead of back to notifications.

Now uses router.back() consistently to properly return to wherever the user came from.

https://claude.ai/code/session_014QzLKgsPb1PHG2CM7EAA43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back-navigation consistency in the settings page. The back button now reliably returns to the previous screen instead of occasionally navigating to a default location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->