### PR TITLE
fix: Load quoted posts that are replies on user page

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -108,6 +108,11 @@ async function fetchPostsOrReplies(ids: string[]): Promise<Post[]> {
     encryptedContent: reply.encryptedContent,
     epoch: reply.epoch,
     nonce: reply.nonce,
+    // Thread context fields
+    parentId: reply.parentId,
+    parentOwnerId: reply.parentOwnerId,
+    // Enrichment metadata
+    _enrichment: reply._enrichment,
   }))
 
   return [...posts, ...convertedReplies]


### PR DESCRIPTION
Quoted content can be either a post or a reply. The user page was only looking for quoted content in the post collection, which meant quoted replies would never load. Added fetchPostsOrReplies helper that tries posts first, then fetches any missing IDs as replies.

This matches the existing implementation in the feed page.

https://claude.ai/code/session_01BGepJoFcYrJP2EKP8uTsXJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quoted content retrieval so quoted items stored as either posts or replies display consistently.
  * Unified quoted-post fetching across profile and post detail flows to reduce inconsistencies and missed quotes.
  * Ensures quoted material is correctly mapped and shown in user profiles and post views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->