### PR TITLE
fix: make login modal dismissible on mobile devices

### DIFF
--- a/components/auth/login-modal.tsx
+++ b/components/auth/login-modal.tsx
@@ -268,26 +268,22 @@ export function LoginModal() {
     <AnimatePresence>
       {isOpen && (
         <>
-          {/* Backdrop */}
+          {/* Modal container - handles backdrop click for dismissal */}
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={handleClose}
-            className={`fixed inset-0 bg-black/60 z-50 ${potatoMode ? '' : 'backdrop-blur-sm'}`}
-          />
-
-          {/* Modal */}
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.95 }}
-            transition={{ duration: 0.2 }}
-            className="fixed inset-0 flex items-center justify-center z-50 px-4 pointer-events-none"
+            className={`fixed inset-0 z-50 flex items-center justify-center px-4 bg-black/60 ${potatoMode ? '' : 'backdrop-blur-sm'}`}
           >
-            <div
-              className="bg-white dark:bg-neutral-900 rounded-2xl shadow-xl w-full max-w-md relative max-h-[90vh] overflow-y-auto pointer-events-auto"
+            {/* Modal content - stop propagation to prevent dismiss when clicking inside */}
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ duration: 0.2 }}
               onClick={(e) => e.stopPropagation()}
+              className="bg-white dark:bg-neutral-900 rounded-2xl shadow-xl w-full max-w-md relative max-h-[90vh] overflow-y-auto"
             >
               {/* Header */}
               <div className="sticky top-0 bg-white dark:bg-neutral-900 px-6 pt-6 pb-4 border-b border-gray-100 dark:border-gray-800">
@@ -485,7 +481,7 @@ export function LoginModal() {
                   </a>
                 </div>
               </form>
-            </div>
+            </motion.div>
           </motion.div>
         </>
       )}


### PR DESCRIPTION
Restructured the modal to use a single container that handles both backdrop
display and click dismissal. Previously, the backdrop and modal container
were separate sibling elements, and touch events on mobile didn't reliably
pass through the pointer-events-none wrapper to reach the backdrop beneath.

Now the outer container handles the dismiss click directly, while the inner
modal content uses stopPropagation to prevent dismissal when interacting
with the form.

https://claude.ai/code/session_016eMc3g9gN4enGaDQVYttcx