### PR TITLE
fix: eliminate gap between testnet banner and home header on mobile

### DIFF
--- a/components/ui/development-banner.tsx
+++ b/components/ui/development-banner.tsx
@@ -1,6 +1,6 @@
 export function DevelopmentBanner() {
   return (
-    <div className="bg-amber-500 text-black px-2 sm:px-4 py-1.5 sm:py-2.5 text-xs sm:text-sm fixed top-0 left-0 right-0 z-50">
+    <div className="bg-amber-500 text-black px-2 sm:px-4 text-xs sm:text-sm fixed top-0 left-0 right-0 z-50 h-[32px] sm:h-[40px] flex items-center justify-center">
       <div className="max-w-7xl mx-auto text-center whitespace-nowrap overflow-hidden">
         <span className="font-bold">TESTNET</span>
         <span className="opacity-80 mx-1">|</span>


### PR DESCRIPTION
The banner's actual height (~30px) didn't match the spacer height (32px),
causing a visible gap. Changed banner to use explicit heights matching
the spacer (h-[32px] on mobile, h-[40px] on desktop) with flexbox centering.

https://claude.ai/code/session_01LHHJRvBEHgxoddhX1r6wi6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated development banner layout with improved sizing consistency and content centering for better visual alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->