### PR TITLE
Move "Mark all as read" button to notification header

### DIFF
--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -197,7 +197,17 @@ function NotificationsPage() {
         <header className={`sticky top-[32px] sm:top-[40px] z-40 bg-white/80 dark:bg-neutral-900/80 border-b border-gray-200 dark:border-gray-800 ${potatoMode ? '' : 'backdrop-blur-xl'}`}>
           <div className="flex items-center justify-between px-4 py-3">
             <h1 className="text-xl font-bold">Notifications</h1>
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-2">
+              {unreadCount > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={markAllAsRead}
+                  className="text-yappr-500 hover:text-yappr-600 text-sm"
+                >
+                  Mark all as read
+                </Button>
+              )}
               {/* Mobile filter dropdown */}
               <div className="md:hidden">
                 <DropdownMenu.Root>
@@ -290,19 +300,6 @@ function NotificationsPage() {
             })}
           </div>
         </header>
-
-        {unreadCount > 0 && (
-          <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-800">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={markAllAsRead}
-              className="text-yappr-500 hover:text-yappr-600"
-            >
-              Mark all as read
-            </Button>
-          </div>
-        )}
 
         {isLoading || !hasFetchedOnce ? (
           <div className="p-8 text-center">


### PR DESCRIPTION
## Summary
Relocated the "Mark all as read" button from a separate section below the header to be integrated directly into the header's action area for improved UI/UX and better space utilization.

## Changes
- Moved the "Mark all as read" button from a dedicated container below the header into the header's right-aligned action area
- Updated the gap spacing in the header action container from `gap-1` to `gap-2` to accommodate the new button placement
- Removed the separate border and padding container that previously housed the button
- Maintained the conditional rendering logic (only shows when `unreadCount > 0`)
- Preserved all button styling and functionality

## Benefits
- More compact and streamlined header design
- Reduces visual clutter by eliminating a separate section
- Improves discoverability by placing the action button in the header where users expect to find controls
- Better alignment with modern UI patterns where header actions are grouped together

https://claude.ai/code/session_01Tgwq8Nzo1UZ5ELYn9ECh3w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Moved the "Mark all as read" button to the notifications header for better visibility and improved layout. The button now appears inline next to the title when unread notifications are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->