### PR TITLE
Docs: clarify inventory formula SKU syntax

### DIFF
--- a/lib/upload/inventory-parser.ts
+++ b/lib/upload/inventory-parser.ts
@@ -257,7 +257,7 @@ function parseCombineShipping(value: string): { type: 'free' | 'extra' | 'no'; e
 
 /**
  * Evaluate formula-based quantities
- * Formulas can reference other SKUs: (SKU-NAME)*5 or SKU-NAME+10
+ * Formulas can reference other SKUs only when wrapped in parentheses: (SKU-NAME)*5
  */
 export function evaluateQuantityFormulas(items: GroupedInventoryItem[]): void {
   // Build SKU -> quantity map
@@ -314,7 +314,7 @@ export function evaluateQuantityFormulas(items: GroupedInventoryItem[]): void {
  */
 function evaluateSingleFormula(formula: string, skuQuantities: Record<string, number>): number | null {
   // Replace SKU references with their quantities
-  // Format: (SKU-NAME) or SKU-NAME
+  // Format: (SKU-NAME) only
   let expression = formula
 
   // Find SKU references in parentheses first: (sku-name)


### PR DESCRIPTION
## Summary
- clarify inventory formula docs to match current parsing (parentheses-only)

## Testing
- Not run (docs-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that SKU references in quantity formulas must be wrapped in parentheses (e.g., `(SKU-NAME)*5`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->