### PR TITLE
Add ProfileHoverCard to followers and following pages

### DIFF
--- a/app/followers/page.tsx
+++ b/app/followers/page.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { formatNumber } from '@/lib/utils'
 import { AlsoKnownAs } from '@/components/ui/also-known-as'
+import { ProfileHoverCard } from '@/components/profile/profile-hover-card'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import toast from 'react-hot-toast'
 import { useSettingsStore } from '@/lib/store'
@@ -351,29 +352,47 @@ function FollowersPage() {
                     className="border-b border-gray-200 dark:border-gray-800 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-950 transition-colors"
                   >
                     <div className="flex items-start gap-3">
-                      <button
-                        onClick={() => router.push(`/user?id=${follower.id}`)}
-                        className="h-12 w-12 rounded-full overflow-hidden bg-white dark:bg-neutral-900 cursor-pointer hover:opacity-80 transition-opacity"
+                      <ProfileHoverCard
+                        userId={follower.id}
+                        username={follower.hasDpnsName ? follower.username : null}
+                        displayName={follower.displayName}
                       >
-                        <UserAvatar userId={follower.id} size="lg" alt={follower.displayName} />
-                      </button>
+                        <button
+                          onClick={() => router.push(`/user?id=${follower.id}`)}
+                          className="h-12 w-12 rounded-full overflow-hidden bg-white dark:bg-neutral-900 cursor-pointer hover:opacity-80 transition-opacity"
+                        >
+                          <UserAvatar userId={follower.id} size="lg" alt={follower.displayName} />
+                        </button>
+                      </ProfileHoverCard>
 
                       <div className="flex-1">
                         <div className="flex items-start justify-between">
                           <div>
-                            <h3
-                              onClick={() => router.push(`/user?id=${follower.id}`)}
-                              className="font-semibold hover:underline cursor-pointer"
+                            <ProfileHoverCard
+                              userId={follower.id}
+                              username={follower.hasDpnsName ? follower.username : null}
+                              displayName={follower.displayName}
                             >
-                              {follower.displayName}
-                            </h3>
-                            {follower.hasDpnsName ? (
-                              <p
+                              <h3
                                 onClick={() => router.push(`/user?id=${follower.id}`)}
-                                className="text-sm text-gray-500 hover:underline cursor-pointer"
+                                className="font-semibold hover:underline cursor-pointer"
                               >
-                                @{follower.username}
-                              </p>
+                                {follower.displayName}
+                              </h3>
+                            </ProfileHoverCard>
+                            {follower.hasDpnsName ? (
+                              <ProfileHoverCard
+                                userId={follower.id}
+                                username={follower.username}
+                                displayName={follower.displayName}
+                              >
+                                <p
+                                  onClick={() => router.push(`/user?id=${follower.id}`)}
+                                  className="text-sm text-gray-500 hover:underline cursor-pointer"
+                                >
+                                  @{follower.username}
+                                </p>
+                              </ProfileHoverCard>
                             ) : (
                               <Tooltip.Provider>
                                 <Tooltip.Root>

--- a/app/following/page.tsx
+++ b/app/following/page.tsx
@@ -38,6 +38,7 @@ const dpns_convert_to_homograph_safe = (input: string): string => {
   }
 }
 import { AlsoKnownAs } from '@/components/ui/also-known-as'
+import { ProfileHoverCard } from '@/components/profile/profile-hover-card'
 import { useSettingsStore } from '@/lib/store'
 
 interface FollowingUser {
@@ -544,28 +545,46 @@ function FollowingPage() {
                         className="border-b border-gray-200 dark:border-gray-800 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-950 transition-colors"
                       >
                         <div className="flex items-start gap-3">
-                          <button
-                            onClick={() => router.push(`/user?id=${searchUser.id}`)}
-                            className="h-12 w-12 rounded-full overflow-hidden bg-white dark:bg-neutral-900 cursor-pointer hover:opacity-80 transition-opacity"
+                          <ProfileHoverCard
+                            userId={searchUser.id}
+                            username={searchUser.username}
+                            displayName={searchUser.displayName}
                           >
-                            <UserAvatar userId={searchUser.id} size="lg" alt={searchUser.displayName} />
-                          </button>
+                            <button
+                              onClick={() => router.push(`/user?id=${searchUser.id}`)}
+                              className="h-12 w-12 rounded-full overflow-hidden bg-white dark:bg-neutral-900 cursor-pointer hover:opacity-80 transition-opacity"
+                            >
+                              <UserAvatar userId={searchUser.id} size="lg" alt={searchUser.displayName} />
+                            </button>
+                          </ProfileHoverCard>
 
                           <div className="flex-1">
                             <div className="flex items-start justify-between">
                               <div>
-                                <h3
-                                  onClick={() => router.push(`/user?id=${searchUser.id}`)}
-                                  className="font-semibold hover:underline cursor-pointer"
+                                <ProfileHoverCard
+                                  userId={searchUser.id}
+                                  username={searchUser.username}
+                                  displayName={searchUser.displayName}
                                 >
-                                  {searchUser.displayName}
-                                </h3>
-                                <p
-                                  onClick={() => router.push(`/user?id=${searchUser.id}`)}
-                                  className="text-sm text-gray-500 hover:underline cursor-pointer"
+                                  <h3
+                                    onClick={() => router.push(`/user?id=${searchUser.id}`)}
+                                    className="font-semibold hover:underline cursor-pointer"
+                                  >
+                                    {searchUser.displayName}
+                                  </h3>
+                                </ProfileHoverCard>
+                                <ProfileHoverCard
+                                  userId={searchUser.id}
+                                  username={searchUser.username}
+                                  displayName={searchUser.displayName}
                                 >
-                                  @{searchUser.username}
-                                </p>
+                                  <p
+                                    onClick={() => router.push(`/user?id=${searchUser.id}`)}
+                                    className="text-sm text-gray-500 hover:underline cursor-pointer"
+                                  >
+                                    @{searchUser.username}
+                                  </p>
+                                </ProfileHoverCard>
                                 {searchUser.allUsernames && searchUser.allUsernames.length > 1 && (
                                   <AlsoKnownAs
                                     primaryUsername={searchUser.username}
@@ -651,29 +670,47 @@ function FollowingPage() {
                     className="border-b border-gray-200 dark:border-gray-800 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-950 transition-colors"
                   >
                     <div className="flex items-start gap-3">
-                      <button
-                        onClick={() => router.push(`/user?id=${followingUser.id}`)}
-                        className="h-12 w-12 rounded-full overflow-hidden bg-white dark:bg-neutral-900 cursor-pointer hover:opacity-80 transition-opacity"
+                      <ProfileHoverCard
+                        userId={followingUser.id}
+                        username={followingUser.hasDpnsName ? followingUser.username : null}
+                        displayName={followingUser.displayName}
                       >
-                        <UserAvatar userId={followingUser.id} size="lg" alt={followingUser.displayName} />
-                      </button>
+                        <button
+                          onClick={() => router.push(`/user?id=${followingUser.id}`)}
+                          className="h-12 w-12 rounded-full overflow-hidden bg-white dark:bg-neutral-900 cursor-pointer hover:opacity-80 transition-opacity"
+                        >
+                          <UserAvatar userId={followingUser.id} size="lg" alt={followingUser.displayName} />
+                        </button>
+                      </ProfileHoverCard>
 
                       <div className="flex-1">
                         <div className="flex items-start justify-between">
                           <div>
-                            <h3
-                              onClick={() => router.push(`/user?id=${followingUser.id}`)}
-                              className="font-semibold hover:underline cursor-pointer"
+                            <ProfileHoverCard
+                              userId={followingUser.id}
+                              username={followingUser.hasDpnsName ? followingUser.username : null}
+                              displayName={followingUser.displayName}
                             >
-                              {followingUser.displayName}
-                            </h3>
-                            {followingUser.hasDpnsName ? (
-                              <p
+                              <h3
                                 onClick={() => router.push(`/user?id=${followingUser.id}`)}
-                                className="text-sm text-gray-500 hover:underline cursor-pointer"
+                                className="font-semibold hover:underline cursor-pointer"
                               >
-                                @{followingUser.username}
-                              </p>
+                                {followingUser.displayName}
+                              </h3>
+                            </ProfileHoverCard>
+                            {followingUser.hasDpnsName ? (
+                              <ProfileHoverCard
+                                userId={followingUser.id}
+                                username={followingUser.username}
+                                displayName={followingUser.displayName}
+                              >
+                                <p
+                                  onClick={() => router.push(`/user?id=${followingUser.id}`)}
+                                  className="text-sm text-gray-500 hover:underline cursor-pointer"
+                                >
+                                  @{followingUser.username}
+                                </p>
+                              </ProfileHoverCard>
                             ) : (
                               <RadixTooltip.Provider>
                                 <RadixTooltip.Root>


### PR DESCRIPTION
## Summary
Integrated the `ProfileHoverCard` component into the followers and following pages to provide hover preview functionality for user profiles, improving the user experience when browsing follower/following lists.

## Changes
- **app/followers/page.tsx**: Wrapped user avatar, display name, and username elements with `ProfileHoverCard` component to enable profile previews on hover
- **app/following/page.tsx**: Applied the same `ProfileHoverCard` integration to both the search results section and the main following list
- Added import for `ProfileHoverCard` component in both files
- Maintained existing click navigation behavior while adding hover preview capability

## Implementation Details
- The `ProfileHoverCard` wraps interactive elements (avatar button, display name heading, and username paragraph) individually
- Conditional logic preserved: username is only shown with hover card when `hasDpnsName` is true in followers/following lists
- All existing styling and click handlers remain unchanged
- The hover card receives appropriate props: `userId`, `username` (conditionally), and `displayName`

https://claude.ai/code/session_01RPptaxpFwe7cuZNWTkW6aX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced interactive hover-card profile previews throughout the followers and following lists.
  * Users can now hover over follower and following entries to preview profile information. The enhancement applies to followers list, following list, and search results, while preserving existing navigation and interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->