### PR TITLE
Disable link previews when post contains media

### DIFF
--- a/components/post/post-card.tsx
+++ b/components/post/post-card.tsx
@@ -706,6 +706,7 @@ export function PostCard({ post, hideAvatar = false, isOwnPost: isOwnPostProp, e
             <PostContent
               content={post.content}
               className="mt-1"
+              disableLinkPreview={post.media && post.media.length > 0}
               hashtagValidations={hashtagValidations}
               onFailedHashtagClick={handleFailedHashtagClick}
               mentionValidations={mentionValidations}


### PR DESCRIPTION
## Summary
Prevent link previews from displaying in post content when the post already contains media attachments.

## Changes
- Added `disableLinkPreview` prop to `PostContent` component in `PostCard`
- Link previews are now disabled when `post.media` array contains one or more items
- This prevents visual clutter and redundancy when media is already present in the post

## Implementation Details
The change uses a simple conditional check: `post.media && post.media.length > 0` to determine whether to disable link previews. This ensures that posts with attached media won't also display link preview cards, providing a cleaner user experience.

https://claude.ai/code/session_01CKTEfwWMFbnB7Pq2onvwFk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Link previews no longer appear when posts already contain media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->