### PR TITLE
Recover posts after ambiguous create errors

### DIFF
--- a/components/compose/compose-modal.tsx
+++ b/components/compose/compose-modal.tsx
@@ -660,7 +660,7 @@ export function ComposeModal() {
         // Determine if this is a reply (to existing post/reply) or a top-level post
         // - If replyingTo is set: all posts in thread are replies
         // - If replyingTo is not set: first post is a top-level post, subsequent are replies
-        const isReply = (i === 0 && replyingTo) || (i > 0 && previousPostId)
+        const isReply = Boolean((i === 0 && replyingTo) || (i > 0 && previousPostId))
         const parentId = i === 0 && replyingTo ? replyingTo.id : previousPostId
         const parentOwnerId = i === 0 && replyingTo
           ? replyingTo.author.id

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -32,6 +32,9 @@ export const POST_RECOVERY_LOOKBACK_MS = 2 * 60 * 1000
 export const POST_RECOVERY_POLL_ATTEMPTS = 3
 export const POST_RECOVERY_POLL_DELAY_MS = 2000
 
+// Pre-flight duplicate detection
+export const POST_DUPLICATE_LOOKBACK_MS = 2 * 60 * 1000
+
 // Document types
 // Note: AVATAR, REPOST, DIRECT_MESSAGE, NOTIFICATION were removed in contract migration
 // - avatar: now in unified profile contract

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -27,6 +27,11 @@ export const INSIGHT_API_CONFIG = {
   timeoutMs: 120000
 } as const
 
+// Post creation recovery (ambiguous errors)
+export const POST_RECOVERY_LOOKBACK_MS = 2 * 60 * 1000
+export const POST_RECOVERY_POLL_ATTEMPTS = 3
+export const POST_RECOVERY_POLL_DELAY_MS = 2000
+
 // Document types
 // Note: AVATAR, REPOST, DIRECT_MESSAGE, NOTIFICATION were removed in contract migration
 // - avatar: now in unified profile contract

--- a/lib/retry-utils.ts
+++ b/lib/retry-utils.ts
@@ -74,7 +74,9 @@ export function isPostCreationAmbiguousError(error: unknown): boolean {
     'temporarily unavailable',
     'service unavailable',
     'consensus error',
-    'quorum not available'
+    'quorum not available',
+    'tenderdash is not available',
+    'tenderdash not available'
   ]
 
   return dashErrors.some(dashError => errorMessage.includes(dashError))

--- a/lib/retry-utils.ts
+++ b/lib/retry-utils.ts
@@ -23,10 +23,8 @@ export interface RetryResult<T> {
 function defaultRetryCondition(error: unknown): boolean {
   if (!error) return false
 
-  const errObj = error as { message?: string; toString?: () => string }
-  const errorMessage = errObj.message?.toLowerCase() || ''
-  const errorString = errObj.toString?.()?.toLowerCase() || ''
-  
+  const errorMessage = getErrorMessage(error).toLowerCase()
+
   // Network-related errors
   const networkErrors = [
     'network error',
@@ -34,6 +32,8 @@ function defaultRetryCondition(error: unknown): boolean {
     'fetch failed',
     'connection refused',
     'timeout',
+    'timed out',
+    'deadline',
     'etimedout',
     'enotfound',
     'econnreset',
@@ -45,7 +45,7 @@ function defaultRetryCondition(error: unknown): boolean {
   
   // Check if it's a retryable error
   return networkErrors.some(networkError => 
-    errorMessage.includes(networkError) || errorString.includes(networkError)
+    errorMessage.includes(networkError)
   )
 }
 
@@ -54,8 +54,21 @@ function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   if (typeof error === 'string') return error
   if (typeof error === 'object') {
-    const errObj = error as { message?: string }
+    const errObj = error as { message?: unknown }
     if (typeof errObj.message === 'string') return errObj.message
+    if (errObj.message && typeof errObj.message === 'object') {
+      try {
+        return JSON.stringify(errObj.message)
+      } catch {
+        return String(errObj.message)
+      }
+    }
+    try {
+      const asJson = JSON.stringify(error)
+      if (asJson && asJson !== '{}') return asJson
+    } catch {
+      // Ignore JSON stringify errors
+    }
   }
   return String(error)
 }

--- a/lib/services/post-service.ts
+++ b/lib/services/post-service.ts
@@ -7,7 +7,8 @@ import { unifiedProfileService } from './unified-profile-service';
 import { identifierToBase58, normalizeSDKResponse, RequestDeduplicator, stringToIdentifierBytes, normalizeBytes, getCurrentUserId as getSessionUserId, createDefaultUser, type DocumentWhereClause } from './sdk-helpers';
 import type { DocumentsQuery } from '@dashevo/wasm-sdk';
 import { seedBlockStatusCache, seedFollowStatusCache } from '../caches/user-status-cache';
-import { retryAsync } from '../retry-utils';
+import { retryAsync, isPostCreationAmbiguousError } from '../retry-utils';
+import { POST_RECOVERY_LOOKBACK_MS, POST_RECOVERY_POLL_ATTEMPTS, POST_RECOVERY_POLL_DELAY_MS } from '../constants';
 import { paginateCount } from './pagination-utils';
 
 export interface PostDocument {
@@ -50,6 +51,15 @@ export interface PostStats {
   replies: number;
   views: number;
 }
+
+type ExpectedPostMatch = {
+  content: string;
+  quotedPostId?: string;
+  quotedPostOwnerId?: string;
+  encryptedContent?: Uint8Array;
+  nonce?: Uint8Array;
+  epoch?: number;
+};
 
 class PostService extends BaseDocumentService<Post> {
   private statsCache: Map<string, { data: PostStats; timestamp: number }> = new Map();
@@ -374,7 +384,101 @@ class PostService extends BaseDocumentService<Post> {
     if (options.primaryHashtag) data.primaryHashtag = options.primaryHashtag;
     if (options.sensitive !== undefined) data.sensitive = options.sensitive;
 
-    return this.create(ownerId, data);
+    const attemptStartedAt = Date.now();
+    const expected: ExpectedPostMatch = {
+      content: data.content as string,
+      quotedPostId: options.quotedPostId,
+      quotedPostOwnerId: options.quotedPostOwnerId,
+      encryptedContent: data.encryptedContent as Uint8Array | undefined,
+      nonce: data.nonce as Uint8Array | undefined,
+      epoch: data.epoch as number | undefined,
+    };
+
+    try {
+      return await this.create(ownerId, data);
+    } catch (error) {
+      if (isPostCreationAmbiguousError(error)) {
+        const recovered = await this.recoverRecentPostMatch(ownerId, expected, attemptStartedAt);
+        if (recovered) {
+          console.warn('Post recovery succeeded after ambiguous error:', recovered.id);
+          this.clearCache();
+          return recovered;
+        }
+        console.warn('Post recovery failed after ambiguous error; rethrowing original error');
+      }
+      throw error;
+    }
+  }
+
+  private async recoverRecentPostMatch(
+    ownerId: string,
+    expected: ExpectedPostMatch,
+    attemptStartedAt: number
+  ): Promise<Post | null> {
+    const minCreatedAt = attemptStartedAt - POST_RECOVERY_LOOKBACK_MS;
+    const isPrivateExpected = !!expected.encryptedContent && !!expected.nonce && typeof expected.epoch === 'number';
+
+    for (let attempt = 1; attempt <= POST_RECOVERY_POLL_ATTEMPTS; attempt++) {
+      try {
+        const result = await this.query({
+          where: [
+            ['$ownerId', '==', ownerId],
+            ['$createdAt', '>', minCreatedAt]
+          ],
+          orderBy: [['$ownerId', 'asc'], ['$createdAt', 'desc']],
+          limit: 20
+        });
+
+        const match = result.documents.find((post) =>
+          this.matchesExpectedPost(post, expected, isPrivateExpected)
+        );
+
+        if (match) {
+          return match;
+        }
+      } catch (error) {
+        console.warn(`Post recovery query failed (attempt ${attempt}/${POST_RECOVERY_POLL_ATTEMPTS}):`, error);
+      }
+
+      if (attempt < POST_RECOVERY_POLL_ATTEMPTS) {
+        await this.sleep(POST_RECOVERY_POLL_DELAY_MS);
+      }
+    }
+
+    return null;
+  }
+
+  private matchesExpectedPost(post: Post, expected: ExpectedPostMatch, isPrivateExpected: boolean): boolean {
+    if (isPrivateExpected) {
+      return !!post.encryptedContent &&
+        !!post.nonce &&
+        typeof post.epoch === 'number' &&
+        this.bytesEqual(expected.encryptedContent, post.encryptedContent) &&
+        this.bytesEqual(expected.nonce, post.nonce) &&
+        expected.epoch === post.epoch;
+    }
+
+    const expectedQuotedId = expected.quotedPostId ?? null;
+    const expectedQuotedOwnerId = expected.quotedPostOwnerId ?? null;
+    const actualQuotedId = post.quotedPostId ?? null;
+    const actualQuotedOwnerId = post.quotedPostOwnerId ?? null;
+
+    return post.content === expected.content &&
+      expectedQuotedId === actualQuotedId &&
+      expectedQuotedOwnerId === actualQuotedOwnerId;
+  }
+
+  private bytesEqual(a?: Uint8Array, b?: Uint8Array): boolean {
+    if (!a || !b) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   /**


### PR DESCRIPTION
## Summary
- add recovery constants and a shared ambiguous-error classifier for post creation
- recover post/reply creation by polling recent documents after ambiguous failures
- keep retry behavior consistent by reusing the shared classifier

## Testing
- Not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recovery for ambiguous post and reply creations: attempts to locate and return recently created items that match your intent before surfacing an error.
  * Duplicate-detection on compose to warn and prevent accidental reposts within a recent lookback window, with an override option.

* **Improvements**
  * Tunable retry and polling behavior for transient/ambiguous errors to reduce false failures and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->