### PR TITLE
feat(messages): display emoji-only DMs larger without bubble

### DIFF
--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -24,6 +24,7 @@ import { DirectMessage, Conversation } from '@/lib/types'
 import toast from 'react-hot-toast'
 import { XMarkIcon, ArrowLeftIcon } from '@heroicons/react/24/outline'
 import { EmojiPicker } from '@/components/compose/emoji-picker'
+import { isEmojiOnly } from '@/lib/utils'
 
 interface UserSearchResult {
   id: string
@@ -708,15 +709,22 @@ function MessagesPage() {
                       className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}
                     >
                       <div className={`max-w-[85%] sm:max-w-[75%] md:max-w-[70%] ${isOwn ? 'order-2' : 'order-1'}`}>
-                        <div
-                          className={`px-4 py-2 rounded-2xl ${
-                            isOwn
-                              ? 'bg-yappr-500 text-white'
-                              : 'bg-gray-100 dark:bg-gray-900'
-                          }`}
-                        >
-                          <p className="text-sm">{message.content}</p>
-                        </div>
+                        {(() => {
+                          const emojiOnly = isEmojiOnly(message.content)
+                          return emojiOnly ? (
+                            <p className={`text-4xl leading-tight ${isOwn ? 'text-right' : 'text-left'}`}>{message.content}</p>
+                          ) : (
+                            <div
+                              className={`px-4 py-2 rounded-2xl ${
+                                isOwn
+                                  ? 'bg-yappr-500 text-white'
+                                  : 'bg-gray-100 dark:bg-gray-900'
+                              }`}
+                            >
+                              <p className="text-sm">{message.content}</p>
+                            </div>
+                          )
+                        })()}
                         <div className={`flex items-center gap-1 mt-1 px-2 ${isOwn ? 'justify-end' : 'justify-start'}`}>
                           <p className="text-xs text-gray-500">
                             {formatDistanceToNow(message.createdAt, { addSuffix: true })}

--- a/components/post/post-content.tsx
+++ b/components/post/post-content.tsx
@@ -10,28 +10,7 @@ import { useLinkPreview, extractFirstUrl, stripTrailingPunctuation } from '@/hoo
 import { useSettingsStore, LinkPreviewChoice } from '@/lib/store'
 import { cashtagDisplayToStorage, normalizeDpnsUsername } from '@/lib/post-helpers'
 import { MentionLink } from './mention-link'
-import { cn } from '@/lib/utils'
-
-/**
- * Checks if content consists only of emoji characters (and optional whitespace).
- * Used to display emoji-only posts with larger text.
- */
-function isEmojiOnly(text: string): boolean {
-  const trimmed = text.trim()
-  if (trimmed.length === 0) return false
-
-  // Match complete emoji sequences only (excludes digits/symbols that \p{Emoji} includes):
-  // - Base: \p{Extended_Pictographic} (actual pictorial emojis)
-  // - Optional: skin tone modifier or variation selector
-  // - Optional: ZWJ-linked sequences (family, profession emojis)
-  // - Only whitespace allowed between emoji sequences
-  // Using RegExp constructor to avoid TS1501 error with es5 target
-  const emojiRegex = new RegExp(
-    '^(?:\\p{Extended_Pictographic}(?:\\p{Emoji_Modifier}|\\uFE0F)?(?:\\u200D\\p{Extended_Pictographic}(?:\\p{Emoji_Modifier}|\\uFE0F)?)*\\s*)+$',
-    'u'
-  )
-  return emojiRegex.test(trimmed)
-}
+import { cn, isEmojiOnly } from '@/lib/utils'
 
 interface PostContentProps {
   content: string

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -82,3 +82,24 @@ export function truncateId(id: string, startChars = 8, endChars = 6): string {
   if (id.length <= startChars + endChars) return id
   return `${id.slice(0, startChars)}...${id.slice(-endChars)}`
 }
+
+/**
+ * Checks if content consists only of emoji characters (and optional whitespace).
+ * Used to display emoji-only content with larger text.
+ */
+export function isEmojiOnly(text: string): boolean {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return false
+
+  // Match complete emoji sequences only (excludes digits/symbols that \p{Emoji} includes):
+  // - Base: \p{Extended_Pictographic} (actual pictorial emojis)
+  // - Optional: skin tone modifier or variation selector
+  // - Optional: ZWJ-linked sequences (family, profession emojis)
+  // - Only whitespace allowed between emoji sequences
+  // Using RegExp constructor to avoid TS1501 error with es5 target
+  const emojiRegex = new RegExp(
+    '^(?:\\p{Extended_Pictographic}(?:\\p{Emoji_Modifier}|\\uFE0F)?(?:\\u200D\\p{Extended_Pictographic}(?:\\p{Emoji_Modifier}|\\uFE0F)?)*\\s*)+$',
+    'u'
+  )
+  return emojiRegex.test(trimmed)
+}


### PR DESCRIPTION
Emoji-only messages now render WhatsApp-style: large text (text-4xl) without the bubble background. Extracts isEmojiOnly to shared utils for reuse across posts and DMs.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated emoji picker into the messaging interface for quick emoji selection
  * Emoji-only messages now render with enhanced visual presentation
  * Added validation feedback for hashtags and mentions in user content

* **Refactor**
  * Centralized emoji detection logic for consistency across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->