### PR TITLE
Allow unauthenticated access to followers and following pages

### DIFF
--- a/app/followers/page.tsx
+++ b/app/followers/page.tsx
@@ -216,11 +216,8 @@ function FollowersPage() {
   }, [setLoading, setError, setData, isOwnProfile, user?.identityId, targetUserId])
 
   useEffect(() => {
-    // Load when we have a user (for own profile) or a targetUserId (for viewing others)
-    if (user || targetUserId) {
-      loadFollowers().catch(err => console.error('Failed to load followers:', err))
-    }
-  }, [loadFollowers, user, targetUserId])
+    loadFollowers().catch(err => console.error('Failed to load followers:', err))
+  }, [loadFollowers])
 
   const handleFollow = async (userId: string) => {
     const authedUser = requireAuth('follow')

--- a/app/following/page.tsx
+++ b/app/following/page.tsx
@@ -230,11 +230,8 @@ function FollowingPage() {
   }, [setLoading, setError, setData, user?.identityId, targetUserId])
 
   useEffect(() => {
-    // Load when we have a user (for own profile) or a targetUserId (for viewing others)
-    if (user || targetUserId) {
-      loadFollowing().catch(err => console.error('Failed to load following:', err))
-    }
-  }, [loadFollowing, user, targetUserId])
+    loadFollowing().catch(err => console.error('Failed to load following:', err))
+  }, [loadFollowing])
 
   const handleUnfollow = async (userId: string) => {
     const authedUser = requireAuth('follow')


### PR DESCRIPTION
## Summary
This PR makes the followers and following pages accessible to unauthenticated users, while maintaining proper null-safety checks for the authenticated user object.

## Key Changes
- Modified `withAuth` wrapper to use `{ optional: true }` on both `/followers` and `/following` pages, allowing unauthenticated users to view public follower/following lists
- Updated `isOwnProfile` logic in both pages to safely check if `user` exists before accessing `user.identityId`, preventing potential null reference errors
- Changed condition from `!targetUserId || targetUserId === user?.identityId` to `!!user && (!targetUserId || targetUserId === user.identityId)` to ensure proper null-safety

## Implementation Details
- The optional authentication allows users to browse public follower/following information without logging in
- The null-safety check ensures that `isOwnProfile` is only true when a user is authenticated AND either no target user ID is specified (viewing own profile) or the target matches the current user's ID
- This maintains the distinction between viewing one's own profile versus viewing another user's public profile

https://claude.ai/code/session_01F7cvp3e3i2X96UVV2QFNPE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Followers and Following pages are now accessible without requiring authentication.

* **Bug Fixes**
  * Updated profile ownership detection on Followers and Following pages to properly handle unauthenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->