### PR TITLE
Center notifications main content on larger screens

### DIFF
--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -182,7 +182,8 @@ function NotificationsPage() {
     <div className="min-h-[calc(100vh-40px)] flex">
       <Sidebar />
 
-      <main className="flex-1 min-w-0 md:max-w-[700px] md:border-x border-gray-200 dark:border-gray-800">
+      <div className="flex-1 flex justify-center min-w-0">
+      <main className="w-full max-w-[700px] md:border-x border-gray-200 dark:border-gray-800">
         <header className={`sticky top-[32px] sm:top-[40px] z-40 bg-white/80 dark:bg-neutral-900/80 border-b border-gray-200 dark:border-gray-800 ${potatoMode ? '' : 'backdrop-blur-xl'}`}>
           <div className="flex items-center justify-between px-4 py-3">
             <h1 className="text-xl font-bold">Notifications</h1>
@@ -401,6 +402,7 @@ function NotificationsPage() {
           </div>
         )}
       </main>
+      </div>
 
       <RightSidebar />
     </div>


### PR DESCRIPTION
## Summary
Refactored the notifications page layout to center the main content area on larger screens while maintaining responsive behavior across all viewport sizes.

## Changes
- Wrapped the `<main>` element with a flex container (`<div>`) that centers its content
- Changed the main element from `flex-1 min-w-0 md:max-w-[700px]` to `w-full max-w-[700px]` for better centering behavior
- Moved responsive max-width constraint from `md:` breakpoint to apply universally, allowing the flex container to handle centering logic
- The flex container uses `justify-center` to center the main content horizontally while maintaining `flex-1` to fill available space

## Implementation Details
- The outer flex container (`flex-1 flex justify-center min-w-0`) ensures the notifications section expands to fill available space and centers its child
- The main element now uses `w-full max-w-[700px]` to constrain width while allowing the parent flex container to handle centering
- Border styling remains on the main element and applies consistently across all screen sizes
- This approach provides better visual balance on ultra-wide displays while preserving the existing mobile and tablet experience

https://claude.ai/code/session_015xsUqHPAVVsLedmHS97HQ7