### PR TITLE
fix(compose): allow image uploads for private posts

### DIFF
--- a/components/compose/compose-modal.tsx
+++ b/components/compose/compose-modal.tsx
@@ -306,8 +306,7 @@ export function ComposeModal() {
   // Disable thread for private posts and inherited encryption replies (private posts are single posts only)
   const canAddThread = threadPosts.length < 10 && !replyingTo && !quotingPost && !willBeEncrypted
   // Check if image attachment is allowed (not including provider connection status)
-  // Private posts can't have images (mediaUrl is stored publicly on chain)
-  const canAttachImage = !willBeEncrypted && !attachedImage
+  const canAttachImage = !attachedImage
 
   // Get the last posted post ID for chaining retries
   const lastPostedId = postedPosts.length > 0
@@ -447,11 +446,7 @@ export function ComposeModal() {
     const imageItem = Array.from(items).find(item => item.type.startsWith('image/'))
     if (!imageItem) return
 
-    // Check if we can attach an image (not encrypted, no existing attachment)
-    if (willBeEncrypted) {
-      toast.error('Images not supported for private posts')
-      return
-    }
+    // Check if we can attach an image
     if (attachedImage) {
       toast.error('Only one image can be attached per post')
       return
@@ -490,7 +485,7 @@ export function ComposeModal() {
         console.error('Failed to upload image:', err)
         toast.error('Failed to upload image')
       })
-  }, [willBeEncrypted, attachedImage, isProviderConnected, upload])
+  }, [attachedImage, isProviderConnected, upload])
 
   const handlePost = async () => {
     const authedUser = requireAuth('post')
@@ -1256,13 +1251,7 @@ export function ComposeModal() {
                                 ? 'text-gray-500 hover:text-yappr-500 hover:bg-gray-100 dark:hover:bg-gray-800'
                                 : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
                             }`}
-                            title={
-                              willBeEncrypted
-                                ? 'Images not supported for private posts'
-                                : attachedImage
-                                ? 'Only one image per post'
-                                : 'Attach image'
-                            }
+                            title={attachedImage ? 'Only one image per post' : 'Attach image'}
                           >
                             <PhotoIcon className="w-5 h-5" />
                           </button>


### PR DESCRIPTION
## Summary

Enables image uploads for private (encrypted) posts by removing the UI restrictions that blocked image attachments. The image URL is included in the encrypted content before encryption, and the existing link preview system renders it after decryption.

## Changes

- Remove `willBeEncrypted` check from `canAttachImage` logic
- Remove error toast when pasting images for private posts
- Update image button tooltip to remove private post restriction message

## Test Plan

- [x] Create a private post with an image attached
- [x] Verify the image appears after decryption
- [x] Verify existing private posts (without images) still display correctly
- [x] Test private posts with teaser + image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Image attachments can now be added to private posts
  * Simplified image button text for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->