### PR TITLE
Add temporary banner for Dash Platform testnet downtime

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Toaster } from 'react-hot-toast'
 import { Providers } from '@/components/providers'
 import ErrorBoundary from '@/components/error-boundary'
 import { DevelopmentBanner } from '@/components/ui/development-banner'
+import { TestnetDowntimeBanner } from '@/components/ui/testnet-downtime-banner'
 import { MobileBottomNav } from '@/components/layout/mobile-bottom-nav'
 import { LoginModal } from '@/components/auth/login-modal'
 import { LinkPreviewModalProvider } from '@/components/post/link-preview'
@@ -31,7 +32,8 @@ export default function RootLayout({
           <Providers>
             <LinkPreviewModalProvider>
               <DevelopmentBanner />
-              <div className="h-[32px] sm:h-[40px]" /> {/* Spacer for fixed banner */}
+              <TestnetDowntimeBanner />
+              <div className="h-[64px] sm:h-[80px]" /> {/* Spacer for fixed banners */}
               <ErrorBoundary level="page">
                 {children}
               </ErrorBoundary>

--- a/components/ui/testnet-downtime-banner.tsx
+++ b/components/ui/testnet-downtime-banner.tsx
@@ -1,0 +1,14 @@
+export function TestnetDowntimeBanner() {
+  return (
+    <div className="bg-red-600 text-white px-2 sm:px-4 text-xs sm:text-sm fixed top-[32px] sm:top-[40px] left-0 right-0 z-50 h-[32px] sm:h-[40px] flex items-center justify-center">
+      <div className="max-w-7xl mx-auto text-center whitespace-nowrap overflow-hidden">
+        <span className="font-bold">OFFLINE</span>
+        <span className="opacity-80 mx-1">|</span>
+        <span className="font-medium">
+          <span className="hidden sm:inline">Dash Platform testnet is currently down for maintenance. Yappr will not function until it is restored.</span>
+          <span className="sm:hidden">Testnet down for maintenance</span>
+        </span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Testnet is currently down for maintenance/reorganization. This adds a red banner below the existing testnet banner to inform users that Yappr will not function until the network is restored.

https://claude.ai/code/session_01U8VPiARd7Lme8ViyPW7X9N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a testnet downtime status banner displayed at the top of the application with an offline indicator and responsive messaging that adapts based on screen size.

* **Layout Updates**
  * Adjusted application spacing to accommodate the new banner alongside existing banners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->