### PR TITLE
Remove unique constraint from social links to allow multiple per platform

### DIFF
--- a/components/profile/social-links-input.tsx
+++ b/components/profile/social-links-input.tsx
@@ -92,12 +92,6 @@ export function SocialLinksInput({
       return
     }
 
-    // Check for duplicate platform (except 'other')
-    if (selectedPlatform !== 'other' && links.some(l => l.platform === selectedPlatform)) {
-      setError(`${getPlatformLabel(selectedPlatform)} is already added`)
-      return
-    }
-
     onChange([...links, { platform: selectedPlatform, handle: handle.trim() }])
     setHandle('')
     setError(null)


### PR DESCRIPTION
Users can now add multiple social links for the same platform (e.g., multiple Twitter accounts). This removes the duplicate platform validation that was preventing this.

https://claude.ai/code/session_01YRmcqKSsgTuD8JbcsWsQtJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now add multiple social media links for the same platform to their profile, enabling greater flexibility in profile customization. This allows managing multiple accounts from the same social network or different account variations with ease. Input validation for non-empty handles and maximum link limits continues to be enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->