### PR TITLE
Fix user page when own profile document is missing

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -136,6 +136,7 @@ function UserProfileContent() {
   const [isFollowing, setIsFollowing] = useState(false)
   const [followLoading, setFollowLoading] = useState(false)
   const [postCount, setPostCount] = useState<number | null>(null)
+  const [profileDocumentMissing, setProfileDocumentMissing] = useState(false)
 
   // Pagination state
   const [hasMore, setHasMore] = useState(true)
@@ -217,39 +218,22 @@ function UserProfileContent() {
     const loadProfileData = async () => {
       try {
         setIsLoading(true)
+        setProfileDocumentMissing(false)
 
         const { unifiedProfileService, postService, followService } = await import('@/lib/services')
 
         // Fetch profile from unified service, posts, and post count in parallel
+        let profileFetchErrored = false
         const [profileResult, postsResult, totalPostCount] = await Promise.all([
-          unifiedProfileService.getProfile(userId).catch(() => null),
+          unifiedProfileService.getProfile(userId).catch(() => { profileFetchErrored = true; return null }),
           postService.getUserPosts(userId, { limit: 50 }).catch(() => ({ documents: [], hasMore: false })),
           postService.countUserPosts(userId).catch(() => 0)
         ])
 
         setPostCount(totalPostCount)
 
-        // If viewing own profile and no profile document exists, verify identity
-        if (!profileResult && isOwnProfile && currentUser?.identityId) {
-          try {
-            const { identityService } = await import('@/lib/services/identity-service')
-            const identity = await identityService.getIdentity(userId)
-
-            if (!identity) {
-              // Identity doesn't exist on platform (possibly wiped) - log out
-              toast.error('Your identity was not found on the network. Please log in again.')
-              await logout()
-              return
-            }
-
-            // Identity exists but no profile document - redirect to create profile
-            router.push('/profile/create')
-            return
-          } catch (identityError) {
-            // Network error checking identity - continue loading page normally
-            console.error('Failed to verify identity for profile check:', identityError)
-          }
-        }
+        // Track whether profile document is genuinely missing (not just a network error)
+        setProfileDocumentMissing(!profileResult && !profileFetchErrored)
 
         // Process profile
         let profileDisplayName = `User ${userId.slice(-6)}`
@@ -482,6 +466,31 @@ function UserProfileContent() {
   // currentUser is intentionally not a dependency - we only want to reload on userId change
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId, enrichProgressively])
+
+  // If own profile document is missing after load, verify identity and redirect
+  useEffect(() => {
+    if (!profileDocumentMissing || !isOwnProfile || !currentUser?.identityId || isLoading) return
+
+    const checkIdentityAndRedirect = async () => {
+      try {
+        const { identityService } = await import('@/lib/services/identity-service')
+        const identity = await identityService.getIdentity(currentUser.identityId)
+
+        if (!identity) {
+          toast.error('Your identity was not found on the network. Please log in again.')
+          await logout()
+          return
+        }
+
+        router.push('/profile/create')
+      } catch (error) {
+        // Network error checking identity - don't take drastic action
+        console.error('Failed to verify identity for profile check:', error)
+      }
+    }
+
+    checkIdentityAndRedirect().catch(err => console.error('Identity check failed:', err))
+  }, [profileDocumentMissing, isOwnProfile, currentUser?.identityId, isLoading, logout, router])
 
   // Define handleStartEdit before the useEffect that uses it
   const handleStartEdit = useCallback(() => {

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -27,7 +27,7 @@ interface AuthContextType {
   error: string | null
   login: (identityId: string, privateKey: string, options?: { skipUsernameCheck?: boolean; rememberMe?: boolean }) => Promise<void>
   loginWithPassword: (username: string, password: string, rememberMe?: boolean) => Promise<void>
-  logout: () => void
+  logout: () => Promise<void>
   updateDPNSUsername: (username: string) => void
   refreshDpnsUsernames: () => Promise<void>
   refreshBalance: () => Promise<void>


### PR DESCRIPTION
When viewing your own profile, if the profile document doesn't exist
on the platform, the page would enter a broken state showing a
skeleton-like fallback. Now it checks identity existence and redirects
appropriately: to /profile/create if the identity still exists, or
logs the user out if the identity is also gone (e.g. platform wipe).

Network errors during the identity check are caught gracefully so the
page continues loading normally rather than taking drastic action.

https://claude.ai/code/session_01FY5bP7AEGsBbBchxQC6knR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logout exposed in the authentication flow for users; sign-out now completes reliably.

* **Bug Fixes**
  * Added identity verification when viewing your own profile; missing identities show an error and sign you out.
  * If you have an identity but no profile, you are redirected to create one.
  * Improved handling of network errors during profile loading so the app continues gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->