### PR TITLE
refactor(blog): fix N+1 queries, deduplicate constants, and memoize values

### DIFF
--- a/components/blog/blocknote-schema.tsx
+++ b/components/blog/blocknote-schema.tsx
@@ -37,6 +37,8 @@ import { IpfsImage } from '@/components/ui/ipfs-image'
 import { isIpfsProtocol } from '@/lib/utils/ipfs-gateway'
 import { extractInlineText } from '@/lib/blog/content-utils'
 
+const CODE_LANGUAGES = ['javascript', 'typescript', 'python', 'rust', 'bash', 'json', 'html', 'css', 'go', 'solidity'] as const
+
 function getHeadingLinks(documentBlocks: unknown[]): Array<{ id: string; text: string }> {
   let index = 0
 
@@ -298,7 +300,7 @@ const codeBlock = createReactBlockSpec(
       ...defaultProps,
       language: {
         default: 'javascript',
-        values: ['javascript', 'typescript', 'python', 'rust', 'bash', 'json', 'html', 'css', 'go', 'solidity'] as const,
+        values: CODE_LANGUAGES,
       },
       code: { default: '' },
     },
@@ -327,7 +329,7 @@ const codeBlock = createReactBlockSpec(
               className="rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-gray-200"
               onChange={(event) => updateBlockProps(editor, block, { language: event.target.value })}
             >
-              {['javascript', 'typescript', 'python', 'rust', 'bash', 'json', 'html', 'css', 'go', 'solidity'].map((language) => (
+              {CODE_LANGUAGES.map((language) => (
                 <option key={language} value={language}>{language}</option>
               ))}
             </select>

--- a/components/blog/blog-home.tsx
+++ b/components/blog/blog-home.tsx
@@ -40,19 +40,10 @@ export function BlogHome({ blog, username }: BlogHomeProps) {
 
         setPosts(result)
 
-        const counts = await Promise.all(
-          result.map(async (post) => {
-            try {
-              const comments = await blogCommentService.getCommentsByPost(post.id, { limit: 100 })
-              return [post.id, comments.length] as const
-            } catch {
-              return [post.id, 0] as const
-            }
-          })
-        )
+        const countMap = await blogCommentService.countCommentsByPostBatch(result.map(p => p.id))
         if (cancelled) return
 
-        setCommentCounts(Object.fromEntries(counts))
+        setCommentCounts(Object.fromEntries(countMap))
       } catch {
         if (!cancelled) setError('Failed to load posts')
       } finally {

--- a/components/blog/blog-post-view.tsx
+++ b/components/blog/blog-post-view.tsx
@@ -69,7 +69,7 @@ export function BlogPostView({ blog, post, username }: BlogPostViewProps) {
   const [commentCount, setCommentCount] = useState(0)
   const { readingMode, fontSize } = useReaderPreferencesStore()
   const readerOverrides = useMemo(() => getReaderOverrideStyle(readingMode), [readingMode])
-  const contentFontSize = getReaderFontSize(fontSize)
+  const contentFontSize = useMemo(() => getReaderFontSize(fontSize), [fontSize])
   const { theme, setTheme } = useTheme()
   const savedThemeRef = useRef<string | undefined>(undefined)
   const commentsRef = useRef<HTMLDivElement>(null)

--- a/lib/blog/content-utils.ts
+++ b/lib/blog/content-utils.ts
@@ -118,13 +118,8 @@ export async function enrichBlogPostsWithAuthors<T extends { ownerId: string; bl
   const { unifiedProfileService } = await import('@/lib/services/unified-profile-service')
 
   const ownerIds = Array.from(new Set(posts.map((p) => p.ownerId)))
-  const [usernameEntries, profileEntries] = await Promise.all([
-    Promise.all(
-      ownerIds.map(async (id) => {
-        const name = await dpnsService.resolveUsername(id).catch(() => null)
-        return [id, name] as const
-      }),
-    ),
+  const [usernameMap, profileEntries] = await Promise.all([
+    dpnsService.resolveUsernamesBatch(ownerIds),
     Promise.all(
       ownerIds.map(async (id) => {
         const profile = await unifiedProfileService.getProfile(id).catch(() => null)
@@ -133,7 +128,6 @@ export async function enrichBlogPostsWithAuthors<T extends { ownerId: string; bl
     ),
   ])
 
-  const usernameMap = new Map(usernameEntries)
   const profileMap = new Map(profileEntries)
 
   return posts.map((post) => ({

--- a/lib/services/blog-comment-service.ts
+++ b/lib/services/blog-comment-service.ts
@@ -2,6 +2,8 @@ import { BaseDocumentService, type QueryOptions } from './document-service'
 import { YAPPR_BLOG_CONTRACT_ID } from '@/lib/constants'
 import type { BlogComment } from '@/lib/types'
 import { identifierToBase58, requireIdentifierBytes } from './sdk-helpers'
+import { getEvoSdk } from './evo-sdk-service'
+import { paginateCount } from './pagination-utils'
 
 export interface BlogCommentQueryOptions {
   limit?: number
@@ -64,6 +66,28 @@ class BlogCommentService extends BaseDocumentService<BlogComment> {
     }
     const result = await this.query(queryOptions)
     return result.documents
+  }
+
+  async countCommentsByPost(blogPostId: string): Promise<number> {
+    try {
+      const sdk = await getEvoSdk()
+      const { count } = await paginateCount(sdk, () => ({
+        dataContractId: this.contractId,
+        documentTypeName: this.documentType,
+        where: [['blogPostId', '==', blogPostId]],
+        orderBy: [['blogPostId', 'asc'], ['$createdAt', 'asc']],
+      }))
+      return count
+    } catch {
+      return 0
+    }
+  }
+
+  async countCommentsByPostBatch(postIds: string[]): Promise<Map<string, number>> {
+    const counts = await Promise.all(
+      postIds.map(async (id) => [id, await this.countCommentsByPost(id)] as const)
+    )
+    return new Map(counts)
   }
 
   async getCommentsByOwner(ownerId: string, options: BlogCommentQueryOptions = {}): Promise<BlogComment[]> {


### PR DESCRIPTION
## Summary

- **Fix N+1 in `enrichBlogPostsWithAuthors`**: replace N individual `resolveUsername()` calls with single `resolveUsernamesBatch()` (batch method already existed, was used everywhere else)
- **Fix N+1 comment counting in blog home**: was fetching up to 100 full comment documents per post just for `.length`; added `countCommentsByPost()` / `countCommentsByPostBatch()` using `paginateCount` (counts without fetching docs)
- **Deduplicate language array in blocknote-schema**: same 10-language array was hardcoded in both prop schema and `<select>` dropdown; extracted to `CODE_LANGUAGES` constant
- **Memoize `contentFontSize` in blog-post-view**: was recalculated on every render unlike adjacent `readerOverrides` which was already memoized

## Test plan

- [ ] Verify blog home loads and shows comment counts correctly
- [ ] Verify explore page blog discovery still resolves author usernames
- [ ] Verify blog post code block language selector still works
- [ ] Verify reading preferences font size changes still apply in blog post view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized blog post loading and comment count retrieval operations for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->