### PR TITLE
fix: add blog to mobile more menu

### DIFF
--- a/components/layout/mobile-bottom-nav.tsx
+++ b/components/layout/mobile-bottom-nav.tsx
@@ -17,6 +17,7 @@ import {
   BuildingStorefrontIcon,
   BellIcon,
   BookmarkIcon,
+  BookOpenIcon,
   UserIcon,
   Cog6ToothIcon,
   UserGroupIcon,
@@ -76,6 +77,7 @@ export function MobileBottomNav() {
   // More menu items - Store first for prominence, then user-specific items
   const moreMenuItems = [
     { name: 'Store', href: '/store', icon: BuildingStorefrontIcon },
+    { name: 'Blog', href: '/blog', icon: BookOpenIcon },
     ...(user ? [
       { name: 'Profile', href: `/user?id=${user.identityId}`, icon: UserIcon },
       { name: 'Notifications', href: '/notifications', icon: BellIcon, badge: isHydrated && unreadNotificationCount > 0 ? unreadNotificationCount : undefined },


### PR DESCRIPTION
# Summary

- add the missing Blog entry to the mobile More menu
- use the existing blog icon so mobile nav matches the desktop sidebar
- keep the diff scoped to the mobile navigation component only

## Validation

- `npm exec eslint -- components/layout/mobile-bottom-nav.tsx`
- manual code check that desktop sidebar already exposes `/blog`
  and the route exists at `app/blog/page.tsx`
- pre-PR review gate:
  `code-review PastaPastaPasta/yappr origin/master fix/mobile-blog-menu`
  with intent
  `Add missing Blog entry to the mobile more menu so mobile nav`
  `matches desktop navigation`
  → `ship`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Blog link to the mobile menu's "More" section, providing users with quick access to blog content directly from their mobile device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->