### PR TITLE
refactor: standardize sdk byte-array handling

### DIFF
--- a/lib/services/block-service.ts
+++ b/lib/services/block-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService, QueryOptions } from './document-service'
 import { stateTransitionService } from './state-transition-service'
-import { identifierToBase58, normalizeSDKResponse, toUint8Array } from './sdk-helpers'
+import { identifierStringToDocumentBytes, identifierToBase58, normalizeSDKResponse, toUint8Array } from './sdk-helpers'
 import { getEvoSdk } from './evo-sdk-service'
 import { DOCUMENT_TYPES } from '../constants'
 import { BloomFilter, BLOOM_FILTER_VERSION } from '../bloom-filter'
@@ -42,7 +42,8 @@ class BlockService extends BaseDocumentService<BlockDocument> {
 
   /**
    * Transform raw block document to typed object.
-   * SDK v3: System fields ($id, $ownerId) are base58, byte array fields are base64.
+   * System identifier fields arrive as base58, while identifier-like document fields may
+   * arrive as base64 or raw bytes in query results.
    */
   protected transformDocument(doc: Record<string, unknown>): BlockDocument {
     const data = (doc.data || doc) as Record<string, unknown>
@@ -87,8 +88,9 @@ class BlockService extends BaseDocumentService<BlockDocument> {
         return { success: true }
       }
 
-      const blockedIdBytes = Array.from(bs58.decode(targetUserId))
-      const documentData: Record<string, unknown> = { blockedId: blockedIdBytes }
+      const documentData: Record<string, unknown> = {
+        blockedId: identifierStringToDocumentBytes(targetUserId),
+      }
       if (message?.trim()) {
         documentData.message = message.trim().slice(0, 280)
       }
@@ -335,7 +337,7 @@ class BlockService extends BaseDocumentService<BlockDocument> {
           existing.documentId,
           userId,
           {
-            filterData: Array.from(existing.filter.serialize()),
+            filterData: existing.filter.serialize(),
             itemCount: existing.filter.itemCount,
             version: BLOOM_FILTER_VERSION
           },
@@ -351,7 +353,7 @@ class BlockService extends BaseDocumentService<BlockDocument> {
           DOCUMENT_TYPES.BLOCK_FILTER,
           userId,
           {
-            filterData: Array.from(filter.serialize()),
+            filterData: filter.serialize(),
             itemCount: filter.itemCount,
             version: BLOOM_FILTER_VERSION
           }
@@ -417,11 +419,10 @@ class BlockService extends BaseDocumentService<BlockDocument> {
   /**
    * Encode an array of base58 user IDs into a byte array.
    */
-  private encodeUserIdArray(userIds: string[]): number[] {
-    const result: number[] = []
-    for (const userId of userIds) {
-      const bytes = bs58.decode(userId)
-      result.push(...Array.from(bytes))
+  private encodeUserIdArray(userIds: string[]): Uint8Array {
+    const result = new Uint8Array(userIds.length * 32)
+    for (let index = 0; index < userIds.length; index++) {
+      result.set(identifierStringToDocumentBytes(userIds[index]), index * 32)
     }
     return result
   }

--- a/lib/services/blog-comment-service.ts
+++ b/lib/services/blog-comment-service.ts
@@ -1,7 +1,7 @@
 import { BaseDocumentService, type QueryOptions } from './document-service'
 import { YAPPR_BLOG_CONTRACT_ID } from '@/lib/constants'
 import type { BlogComment } from '@/lib/types'
-import { identifierToBase58, requireIdentifierBytes } from './sdk-helpers'
+import { identifierToBase58, requireDocumentIdentifierBytes } from './sdk-helpers'
 import { getEvoSdk } from './evo-sdk-service'
 import { paginateCount } from './pagination-utils'
 
@@ -43,8 +43,8 @@ class BlogCommentService extends BaseDocumentService<BlogComment> {
     }
 
     return this.create(ownerId, {
-      blogPostId: requireIdentifierBytes(blogPostId, 'blogPostId'),
-      blogPostOwnerId: requireIdentifierBytes(blogPostOwnerId, 'blogPostOwnerId'),
+      blogPostId: requireDocumentIdentifierBytes(blogPostId, 'blogPostId'),
+      blogPostOwnerId: requireDocumentIdentifierBytes(blogPostOwnerId, 'blogPostOwnerId'),
       content: trimmedContent,
     })
   }

--- a/lib/services/blog-follow-service.ts
+++ b/lib/services/blog-follow-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { stringToIdentifierBytes, RequestDeduplicator, transformDocumentWithField } from './sdk-helpers';
+import { identifierStringToDocumentBytes, RequestDeduplicator, transformDocumentWithField } from './sdk-helpers';
 import { getEvoSdk } from './evo-sdk-service';
 import { YAPPR_BLOG_CONTRACT_ID } from '../constants';
 import { paginateCount, paginateFetchAll } from './pagination-utils';
@@ -47,7 +47,7 @@ class BlogFollowService extends BaseDocumentService<BlogFollowDocument> {
         this.contractId,
         this.documentType,
         userId,
-        { blogId: stringToIdentifierBytes(blogId) }
+        { blogId: identifierStringToDocumentBytes(blogId) }
       );
     } catch (error) {
       logger.error('Error following blog:', error);

--- a/lib/services/blog-post-service.ts
+++ b/lib/services/blog-post-service.ts
@@ -1,7 +1,7 @@
 import { BaseDocumentService, type QueryOptions } from './document-service'
 import { BLOG_CHUNK_SIZE, BLOG_MAX_CHUNKS, BLOG_POST_SIZE_LIMIT, YAPPR_BLOG_CONTRACT_ID } from '@/lib/constants'
 import type { BlogPost } from '@/lib/types'
-import { identifierToBase58, normalizeBytes, requireIdentifierBytes } from './sdk-helpers'
+import { identifierToBase58, normalizeBytes, requireDocumentIdentifierBytes } from './sdk-helpers'
 import { compressContent, decompressContent, joinChunks, splitIntoChunks } from '@/lib/utils/compression'
 import { generateSlug } from '@/lib/utils/slug'
 
@@ -113,7 +113,7 @@ class BlogPostService extends BaseDocumentService<BlogPost> {
     const chunks = splitIntoChunks(compressed, BLOG_CHUNK_SIZE)
     const buildPayload = (finalSlug: string): Record<string, unknown> => {
       const payload: Record<string, unknown> = {
-        blogId: requireIdentifierBytes(data.blogId, 'blogId'),
+        blogId: requireDocumentIdentifierBytes(data.blogId, 'blogId'),
         title: data.title,
         data0: chunks[0],
         slug: finalSlug,

--- a/lib/services/bookmark-service.ts
+++ b/lib/services/bookmark-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { transformDocumentWithField, stringToIdentifierBytes } from './sdk-helpers';
+import { transformDocumentWithField, identifierStringToDocumentBytes } from './sdk-helpers';
 import { paginateFetchAll } from './pagination-utils';
 
 export interface BookmarkDocument {
@@ -37,7 +37,7 @@ class BookmarkService extends BaseDocumentService<BookmarkDocument> {
         this.contractId,
         this.documentType,
         ownerId,
-        { postId: stringToIdentifierBytes(postId) }
+        { postId: identifierStringToDocumentBytes(postId) }
       );
 
       return result.success;

--- a/lib/services/dashpay-contacts-service.ts
+++ b/lib/services/dashpay-contacts-service.ts
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
  */
 
 import { getEvoSdk } from './evo-sdk-service';
-import { queryDocuments, identifierToBase58 } from './sdk-helpers';
+import { identifierStringToLegacyNumberArray, queryDocuments, identifierToBase58 } from './sdk-helpers';
 import { followService } from './follow-service';
 import { dpnsService } from './dpns-service';
 import { unifiedProfileService, UnifiedProfileDocument } from './unified-profile-service';
@@ -116,16 +116,16 @@ class DashPayContactsService {
 
   /**
    * Get all contact requests sent TO the user (incoming)
-   * Uses index: userIdCreatedAt
-   * Note: toUserId is a 32-byte array field, requires byte array for query
+   * Uses index: userIdCreatedAt.
+   *
+   * This is a raw query over an ordinary byte-array field, so it uses the legacy
+   * JSON `number[]` operand shape instead of the typed-write `Uint8Array` helper.
    */
   async getIncomingContactRequests(userId: string): Promise<ContactRequestDocument[]> {
     try {
       const sdk = await getEvoSdk();
 
-      // Convert userId from base58 to byte array for the query
-      // toUserId is stored as a 32-byte array in the contract
-      const userIdBytes = Array.from(bs58.decode(userId));
+      const userIdBytes = identifierStringToLegacyNumberArray(userId);
 
       const documents = await queryDocuments(sdk, {
         dataContractId: DASHPAY_CONTRACT_ID,

--- a/lib/services/direct-message-service.ts
+++ b/lib/services/direct-message-service.ts
@@ -4,7 +4,11 @@ import { stateTransitionService } from './state-transition-service'
 import { identityService } from './identity-service'
 import { dpnsService } from './dpns-service'
 import { unifiedProfileService } from './unified-profile-service'
-import type { DocumentWhereClause } from './sdk-helpers'
+import {
+  bytesToBase64QueryOperand,
+  identifierStringToDocumentBytes,
+  type DocumentWhereClause,
+} from './sdk-helpers'
 import {
   DirectMessage,
   Conversation
@@ -76,21 +80,17 @@ class DirectMessageService {
         // Check if sender's identity uses hash160 (no full pubkey on-chain)
         const needsPubKeyInInvite = await this.identityUsesHash160(senderId)
 
-        // All byteArray fields >= 10 bytes, so Array.from works for platform's byte detection
-        const conversationIdArray = Array.from(conversationIdBytes)
-        const senderPubKeyArray = needsPubKeyInInvite ? Array.from(senderPubKey) : undefined
+        const conversationIdDocumentBytes = conversationIdBytes
+        const senderPubKeyDocumentBytes = needsPubKeyInInvite ? senderPubKey : undefined
 
         const inviteResult = await stateTransitionService.createDocument(
           this.contractId,
           'conversationInvite',
           senderId,
           {
-            // recipientId is an Identifier type - must be byte array
-            recipientId: Array.from(bs58.decode(recipientId)),
-            // conversationId as array (10 bytes >= platform threshold)
-            conversationId: conversationIdArray,
-            // senderPubKey as array (33 bytes)
-            ...(senderPubKeyArray ? { senderPubKey: senderPubKeyArray } : {})
+            recipientId: identifierStringToDocumentBytes(recipientId),
+            conversationId: conversationIdDocumentBytes,
+            ...(senderPubKeyDocumentBytes ? { senderPubKey: senderPubKeyDocumentBytes } : {})
           }
         )
 
@@ -103,18 +103,13 @@ class DirectMessageService {
       // 5. Encrypt the message to binary format
       const encryptedContent = await encryptToBinary(content, privateKey, recipientPubKey)
 
-      // 6. Create directMessage document
-      // All byteArray fields >= 10 bytes, so Array.from works for platform's byte detection
-      const conversationIdArray = Array.from(conversationIdBytes)
-      const encryptedContentArray = Array.from(encryptedContent)
-
       const result = await stateTransitionService.createDocument(
         this.contractId,
         'directMessage',
         senderId,
         {
-          conversationId: conversationIdArray,
-          encryptedContent: encryptedContentArray
+          conversationId: conversationIdBytes,
+          encryptedContent
         }
       )
 
@@ -383,9 +378,10 @@ class DirectMessageService {
   ): Promise<Record<string, unknown>[]> {
     try {
       const sdk = await getEvoSdk()
-      // Decode base58 conversationId, then encode as base64 for SDK
+      // Raw query path: conversationId is an ordinary byte-array field, so use the shared
+      // base64 query operand helper rather than the typed-write Uint8Array shape.
       const convIdBytes = bs58.decode(conversationId)
-      const convIdBase64 = Buffer.from(convIdBytes).toString('base64')
+      const convIdBase64 = bytesToBase64QueryOperand(convIdBytes)
 
       // Build where clause - add timestamp filter if provided
       const where: DocumentWhereClause[] = [['conversationId', '==', convIdBase64]]
@@ -416,7 +412,6 @@ class DirectMessageService {
     try {
       const existingReceipt = await this.getMyReadReceipt(userId, conversationId)
       const convIdBytes = bs58.decode(conversationId)
-      const conversationIdArray = Array.from(convIdBytes)
 
       if (existingReceipt) {
         // Update existing receipt - platform will set $updatedAt
@@ -425,7 +420,7 @@ class DirectMessageService {
           'readReceipt',
           existingReceipt.$id,
           userId,
-          { conversationId: conversationIdArray },
+          { conversationId: convIdBytes },
           existingReceipt.$revision || 0
         )
       } else {
@@ -434,7 +429,7 @@ class DirectMessageService {
           this.contractId,
           'readReceipt',
           userId,
-          { conversationId: conversationIdArray }
+          { conversationId: convIdBytes }
         )
       }
     } catch (error) {
@@ -614,7 +609,7 @@ class DirectMessageService {
     try {
       const sdk = await getEvoSdk()
 
-      // recipientId has contentMediaType "application/x.dash.dpp.identifier" so use base58 string
+      // Raw query path: recipientId is identifier-like, so keep the base58 string operand.
       const response = await sdk.documents.query({
         dataContractId: this.contractId,
         documentTypeName: 'conversationInvite',
@@ -652,9 +647,9 @@ class DirectMessageService {
   ): Promise<{ lastReadAt: number } | null> {
     try {
       const sdk = await getEvoSdk()
-      // Decode base58 conversationId, then encode as base64 for SDK
+      // Raw query path: conversationId is an ordinary byte-array field.
       const convIdBytes = bs58.decode(conversationId)
-      const convIdBase64 = Buffer.from(convIdBytes).toString('base64')
+      const convIdBase64 = bytesToBase64QueryOperand(convIdBytes)
 
       const response = await sdk.documents.query({
         dataContractId: this.contractId,
@@ -690,7 +685,7 @@ class DirectMessageService {
     try {
       const sdk = await getEvoSdk()
       const convIdBytes = bs58.decode(conversationId)
-      const convIdBase64 = Buffer.from(convIdBytes).toString('base64')
+      const convIdBase64 = bytesToBase64QueryOperand(convIdBytes)
 
       const response = await sdk.documents.query({
         dataContractId: this.contractId,

--- a/lib/services/document-builder-service.ts
+++ b/lib/services/document-builder-service.ts
@@ -5,6 +5,8 @@
  * for use with the new typed state transition APIs in @dashevo/evo-sdk
  *
  * The new API requires Document WASM objects instead of plain data objects.
+ * Binary properties on this path should stay as `Uint8Array`; this layer does not convert them
+ * into JSON-style `number[]`.
  *
  * IMPORTANT: We import the Document class from @dashevo/evo-sdk which re-exports
  * from the shared @dashevo/wasm-sdk module. By calling getEvoSdk() first, we ensure
@@ -31,7 +33,7 @@ class DocumentBuilderService {
    * @param contractId - The data contract ID
    * @param documentTypeName - The document type name (e.g., 'post', 'profile')
    * @param ownerId - The identity ID that owns this document
-   * @param data - The document data fields
+   * @param data - The document data fields (`Uint8Array` for binary fields on typed writes)
    * @returns A WASM Document object ready for creation
    */
   async buildDocumentForCreate(
@@ -66,7 +68,7 @@ class DocumentBuilderService {
    * @param documentTypeName - The document type name
    * @param documentId - The existing document's ID
    * @param ownerId - The identity ID that owns this document
-   * @param data - The updated document data fields
+   * @param data - The updated document data fields (`Uint8Array` for binary fields on typed writes)
    * @param newRevision - The new revision number (current revision + 1)
    * @returns A WASM Document object ready for replacement
    */

--- a/lib/services/document-service.ts
+++ b/lib/services/document-service.ts
@@ -20,7 +20,7 @@ export interface DocumentResult<T> {
 
 /**
  * Query raw documents through the shared document-service path.
- * This keeps SDK query behavior centralized in one layer.
+ * This keeps the raw `sdk.documents.query(...)` behavior centralized in one layer.
  */
 export async function queryRawDocuments(options: QueryDocumentsOptions): Promise<Record<string, unknown>[]> {
   const sdk = await getEvoSdk();
@@ -88,7 +88,8 @@ export abstract class BaseDocumentService<T> {
   }
 
   /**
-   * Query documents
+   * Query documents through the raw query path.
+   * `where` operands must already use the correct query encoding for each field.
    */
   async query(options: QueryOptions = {}): Promise<DocumentResult<T>> {
     try {
@@ -166,7 +167,8 @@ export abstract class BaseDocumentService<T> {
   }
 
   /**
-   * Create a new document
+   * Create a new document through the typed `Document` path.
+   * Binary fields should already be `Uint8Array` when they reach this layer.
    */
   async create(ownerId: string, data: Record<string, unknown>): Promise<T> {
     try {
@@ -220,7 +222,8 @@ export abstract class BaseDocumentService<T> {
   }
 
   /**
-   * Update a document
+   * Update a document through the typed `Document` replace path.
+   * Binary fields should already be `Uint8Array` when they reach this layer.
    */
   async update(documentId: string, ownerId: string, data: Record<string, unknown>): Promise<T> {
     try {

--- a/lib/services/follow-service.ts
+++ b/lib/services/follow-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { stringToIdentifierBytes, RequestDeduplicator, transformDocumentWithField } from './sdk-helpers';
+import { identifierStringToDocumentBytes, RequestDeduplicator, transformDocumentWithField } from './sdk-helpers';
 import { getEvoSdk } from './evo-sdk-service';
 import { paginateCount, paginateFetchAll } from './pagination-utils';
 
@@ -41,7 +41,7 @@ class FollowService extends BaseDocumentService<FollowDocument> {
         this.contractId,
         this.documentType,
         followerUserId,
-        { followingId: stringToIdentifierBytes(targetUserId) }
+        { followingId: identifierStringToDocumentBytes(targetUserId) }
       );
 
       return result;

--- a/lib/services/hashtag-service.ts
+++ b/lib/services/hashtag-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { identifierToBase58, normalizeSDKResponse } from './sdk-helpers';
+import { identifierStringToDocumentBytes, identifierToBase58, normalizeSDKResponse } from './sdk-helpers';
 import { paginateCount, paginateFetchAll } from './pagination-utils';
 
 export interface PostHashtagDocument {
@@ -30,14 +30,15 @@ class HashtagService extends BaseDocumentService<PostHashtagDocument> {
 
   /**
    * Transform document from SDK response to typed object
-   * SDK v3: System fields ($id, $ownerId) are base58, byte array fields (postId) are base64
+   * System identifier fields arrive as base58, while identifier-like document fields may
+   * arrive as base64 or raw bytes in query results.
    */
   protected transformDocument(doc: Record<string, unknown>): PostHashtagDocument {
     const data = (doc.data || doc) as Record<string, unknown>;
     const rawPostId = data.postId || doc.postId;
     const hashtag = (data.hashtag || doc.hashtag) as string;
 
-    // Convert postId from base64 to base58 (byte array field)
+    // Normalize the identifier-like postId field to base58.
     const postId = rawPostId ? identifierToBase58(rawPostId) : '';
     if (rawPostId && !postId) {
       logger.error('HashtagService: Invalid postId format:', rawPostId);
@@ -71,18 +72,13 @@ class HashtagService extends BaseDocumentService<PostHashtagDocument> {
         return true;
       }
 
-      // Convert postId to byte array
-      const bs58Module = await import('bs58');
-      const bs58 = bs58Module.default;
-      const postIdBytes = Array.from(bs58.decode(postId));
-
       // Create document via state transition
       const result = await stateTransitionService.createDocument(
         this.contractId,
         this.documentType,
         ownerId,
         {
-          postId: postIdBytes,
+          postId: identifierStringToDocumentBytes(postId),
           hashtag: normalizedTag
         }
       );

--- a/lib/services/like-service.ts
+++ b/lib/services/like-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { stringToIdentifierBytes, normalizeSDKResponse, identifierToBase58 } from './sdk-helpers';
+import { identifierStringToDocumentBytes, normalizeSDKResponse, identifierToBase58 } from './sdk-helpers';
 import { paginateFetchAll } from './pagination-utils';
 
 export interface LikeDocument {
@@ -57,12 +57,12 @@ class LikeService extends BaseDocumentService<LikeDocument> {
 
       // Build document data
       const documentData: Record<string, unknown> = {
-        postId: stringToIdentifierBytes(postId)
+        postId: identifierStringToDocumentBytes(postId)
       };
 
       // Add postOwnerId if provided (for notification queries)
       if (postOwnerId) {
-        documentData.postOwnerId = stringToIdentifierBytes(postOwnerId);
+        documentData.postOwnerId = identifierStringToDocumentBytes(postOwnerId);
       }
 
       // Use state transition service for creation

--- a/lib/services/mention-service.ts
+++ b/lib/services/mention-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService } from './document-service';
 import { stateTransitionService } from './state-transition-service';
-import { identifierToBase58, normalizeSDKResponse, stringToIdentifierBytes } from './sdk-helpers';
+import { identifierToBase58, normalizeSDKResponse, identifierStringToDocumentBytes } from './sdk-helpers';
 import { dpnsService } from './dpns-service';
 import { paginateFetchAll } from './pagination-utils';
 
@@ -20,14 +20,15 @@ class MentionService extends BaseDocumentService<PostMentionDocument> {
 
   /**
    * Transform document from SDK response to typed object
-   * SDK v3: System fields ($id, $ownerId) are base58, byte array fields are base64
+   * System identifier fields arrive as base58, while identifier-like document fields may
+   * arrive as base64 or raw bytes in query results.
    */
   protected transformDocument(doc: Record<string, unknown>): PostMentionDocument {
     const data = (doc.data || doc) as Record<string, unknown>;
     const rawPostId = data.postId || doc.postId;
     const rawMentionedUserId = data.mentionedUserId || doc.mentionedUserId;
 
-    // Convert byte array fields from base64 to base58
+    // Normalize identifier-like fields to base58 for app-level use.
     const postId = rawPostId ? identifierToBase58(rawPostId) : '';
     const mentionedUserId = rawMentionedUserId ? identifierToBase58(rawMentionedUserId) : '';
 
@@ -68,19 +69,19 @@ class MentionService extends BaseDocumentService<PostMentionDocument> {
         return true;
       }
 
-      // Convert IDs to byte arrays using shared helper with defensive error handling
-      let postIdBytes: number[];
-      let mentionedUserIdBytes: number[];
+      // Typed writes use Uint8Array for identifier-like fields.
+      let postIdBytes: Uint8Array;
+      let mentionedUserIdBytes: Uint8Array;
 
       try {
-        postIdBytes = stringToIdentifierBytes(postId);
+        postIdBytes = identifierStringToDocumentBytes(postId);
       } catch (decodeError) {
         logger.error('MentionService: Invalid base58 postId:', postId, decodeError);
         return false;
       }
 
       try {
-        mentionedUserIdBytes = stringToIdentifierBytes(mentionedUserId);
+        mentionedUserIdBytes = identifierStringToDocumentBytes(mentionedUserId);
       } catch (decodeError) {
         logger.error('MentionService: Invalid base58 mentionedUserId:', mentionedUserId, decodeError);
         return false;
@@ -175,8 +176,7 @@ class MentionService extends BaseDocumentService<PostMentionDocument> {
     try {
       const sdk = await import('../services/evo-sdk-service').then(m => m.getEvoSdk());
 
-      // Use byPost index - simple query by postId only
-      // SDK handles string to byte array conversion for identifier fields
+      // Raw query path: postId is identifier-like, so keep the base58 string operand.
       const response = await sdk.documents.query({
         dataContractId: this.contractId,
         documentTypeName: this.documentType,

--- a/lib/services/order-status-service.ts
+++ b/lib/services/order-status-service.ts
@@ -7,7 +7,7 @@
 
 import { BaseDocumentService } from './document-service';
 import { YAPPR_STOREFRONT_CONTRACT_ID, STOREFRONT_DOCUMENT_TYPES } from '../constants';
-import { identifierToBase58, stringToIdentifierBytes } from './sdk-helpers';
+import { identifierToBase58, identifierStringToDocumentBytes } from './sdk-helpers';
 import type {
   OrderStatusUpdate,
   OrderStatusUpdateDocument,
@@ -94,7 +94,7 @@ class OrderStatusService extends BaseDocumentService<OrderStatusUpdate> {
     }
   ): Promise<OrderStatusUpdate> {
     const documentData: Record<string, unknown> = {
-      orderId: stringToIdentifierBytes(orderId),
+      orderId: identifierStringToDocumentBytes(orderId),
       status: data.status
     };
 

--- a/lib/services/post-service.ts
+++ b/lib/services/post-service.ts
@@ -2,7 +2,7 @@ import { logger } from '@/lib/logger';
 import { BaseDocumentService, QueryOptions, DocumentResult } from './document-service';
 import { Post, PostQueryOptions } from '../../types';
 import type { BlogPost } from '@/lib/types';
-import { identifierToBase58, RequestDeduplicator, stringToIdentifierBytes, normalizeBytes, getCurrentUserId as getSessionUserId, createDefaultUser } from './sdk-helpers';
+import { identifierToBase58, RequestDeduplicator, identifierStringToDocumentBytes, normalizeBytes, getCurrentUserId as getSessionUserId, createDefaultUser } from './sdk-helpers';
 import { paginateCount } from './pagination-utils';
 import { fetchBatchPostStats, fetchBatchUserInteractions, fetchPostStats, fetchUserInteractions } from './post-stats-helpers';
 import { enrichPostFull as enrichPostFullHelper, enrichPostsBatch as enrichPostsBatchHelper, resolvePostAuthor as resolvePostAuthorHelper } from './post-enrichment-helpers';
@@ -74,7 +74,7 @@ class PostService extends BaseDocumentService<Post> {
 
     // SDK v3 toJSON() returns:
     // - System fields ($id, $ownerId, $createdAt): base58 strings
-    // - Byte array fields (replyToPostId, etc): base64 strings (need conversion)
+    // - Identifier-like document fields (quotedPostId, etc): base64 strings or byte arrays
     // Handle both $ prefixed (query responses) and non-prefixed (creation responses) fields
     const id = (doc.$id || doc.id) as string;
     const ownerId = (doc.$ownerId || doc.ownerId) as string;
@@ -84,11 +84,10 @@ class PostService extends BaseDocumentService<Post> {
     const content = (data.content || doc.content || '') as string;
     const mediaUrl = (data.mediaUrl || doc.mediaUrl) as string | undefined;
 
-    // Convert quotedPostId from base64 to base58 for consistent storage
+    // Normalize identifier-like fields to base58 for consistent storage.
     const rawQuotedPostId = data.quotedPostId || doc.quotedPostId;
     const quotedPostId = rawQuotedPostId ? identifierToBase58(rawQuotedPostId) || undefined : undefined;
 
-    // Convert quotedPostOwnerId from base64 to base58 for consistent storage
     const rawQuotedPostOwnerId = data.quotedPostOwnerId || doc.quotedPostOwnerId;
     const quotedPostOwnerId = rawQuotedPostOwnerId ? identifierToBase58(rawQuotedPostOwnerId) || undefined : undefined;
 
@@ -260,8 +259,8 @@ class PostService extends BaseDocumentService<Post> {
 
     // Add optional fields (use contract field names)
     if (options.mediaUrl) data.mediaUrl = options.mediaUrl;
-    if (options.quotedPostId) data.quotedPostId = stringToIdentifierBytes(options.quotedPostId);
-    if (options.quotedPostOwnerId) data.quotedPostOwnerId = stringToIdentifierBytes(options.quotedPostOwnerId);
+    if (options.quotedPostId) data.quotedPostId = identifierStringToDocumentBytes(options.quotedPostId);
+    if (options.quotedPostOwnerId) data.quotedPostOwnerId = identifierStringToDocumentBytes(options.quotedPostOwnerId);
     if (options.firstMentionId) data.firstMentionId = options.firstMentionId;
     if (options.primaryHashtag) data.primaryHashtag = options.primaryHashtag;
     if (options.sensitive !== undefined) data.sensitive = options.sensitive;

--- a/lib/services/private-feed-follower-service.ts
+++ b/lib/services/private-feed-follower-service.ts
@@ -123,15 +123,14 @@ class PrivateFeedFollowerService {
         return { success: false, error: 'Request already pending' };
       }
 
-      // 4. Create FollowRequest document
-      // targetId must be a byte array (Identifier type in contract)
+      // 4. Create FollowRequest document through the typed write path.
       const documentData: Record<string, unknown> = {
-        targetId: Array.from(identifierToBytes(ownerId)),
+        targetId: identifierToBytes(ownerId),
       };
 
       // Include public key if provided (for hash160-only keys on identity)
       if (publicKey) {
-        documentData.publicKey = Array.from(publicKey);
+        documentData.publicKey = publicKey;
       }
 
       logger.info('Creating FollowRequest:', { targetId: ownerId });

--- a/lib/services/private-feed-service.ts
+++ b/lib/services/private-feed-service.ts
@@ -282,11 +282,12 @@ class PrivateFeedService {
         aad
       );
 
-      // 6. Create PrivateFeedState document (SPEC §8.1 step 5)
+      // 6. Create PrivateFeedState document (SPEC §8.1 step 5).
+      // This is a typed write, so binary fields stay as Uint8Array.
       const documentData = {
         treeCapacity: TREE_CAPACITY,
         maxEpoch: MAX_EPOCH,
-        encryptedSeed: Array.from(encryptedSeed), // Convert to array for platform
+        encryptedSeed,
       };
 
       logger.info('Creating PrivateFeedState document:', {
@@ -473,13 +474,12 @@ class PrivateFeedService {
         aad
       );
 
-      // 11. Create PrivateFeedGrant document
-      // recipientId must be a byte array (Identifier type in contract)
+      // 11. Create PrivateFeedGrant document.
       const documentData = {
-        recipientId: Array.from(identifierToBytes(requesterId)),
+        recipientId: identifierToBytes(requesterId),
         leafIndex,
         epoch: localEpoch,
-        encryptedPayload: Array.from(encryptedPayload),
+        encryptedPayload,
       };
 
       logger.info('Creating PrivateFeedGrant document:', {
@@ -749,8 +749,8 @@ class PrivateFeedService {
       const rekeyData = {
         epoch: newEpoch,
         revokedLeaf: leafIndex,
-        packets: Array.from(encodedPackets),
-        encryptedCEK: Array.from(encryptedCEK),
+        packets: encodedPackets,
+        encryptedCEK,
       };
 
       logger.info('Creating PrivateFeedRekey document:', {
@@ -1057,7 +1057,7 @@ class PrivateFeedService {
       const updateData = {
         treeCapacity: TREE_CAPACITY,
         maxEpoch: MAX_EPOCH,
-        encryptedSeed: Array.from(newEncryptedSeed),
+        encryptedSeed: newEncryptedSeed,
       };
 
       logger.info('Resetting PrivateFeedState document:', {
@@ -1331,10 +1331,10 @@ export type { PrivateFeedService };
  * Encrypted post data ready for document creation
  */
 export interface EncryptedPostData {
-  encryptedContent: number[];  // Array for platform serialization
+  encryptedContent: Uint8Array;
   epoch: number;
-  nonce: number[];             // Array for platform serialization
-  teaser?: string;             // Optional public teaser
+  nonce: Uint8Array;
+  teaser?: string;
 }
 
 /**
@@ -1457,9 +1457,9 @@ export async function prepareOwnerEncryption(
     return {
       success: true,
       data: {
-        encryptedContent: Array.from(encrypted.ciphertext),
+        encryptedContent: encrypted.ciphertext,
         epoch: currentEpoch,
-        nonce: Array.from(encrypted.nonce),
+        nonce: encrypted.nonce,
         teaser,
       },
     };
@@ -1537,9 +1537,9 @@ export async function prepareInheritedEncryption(
     return {
       success: true,
       data: {
-        encryptedContent: Array.from(encrypted.ciphertext),
+        encryptedContent: encrypted.ciphertext,
         epoch: source.epoch,
-        nonce: Array.from(encrypted.nonce),
+        nonce: encrypted.nonce,
       },
     };
   } catch (error) {

--- a/lib/services/profile-service.ts
+++ b/lib/services/profile-service.ts
@@ -439,8 +439,7 @@ class ProfileService extends BaseDocumentService<User> {
 
       const sdk = await getEvoSdk();
 
-      // Query profiles where $ownerId is in the array
-      // SDK v3 expects base58 identifier strings for 'in' queries on system fields
+      // Raw query path: system identifier fields keep their base58 string operands.
       const response = await sdk.documents.query({
         dataContractId: this.contractId,
         documentTypeName: this.documentType,

--- a/lib/services/reply-service.ts
+++ b/lib/services/reply-service.ts
@@ -3,7 +3,7 @@ import { BaseDocumentService, QueryOptions, DocumentResult } from './document-se
 import { Reply, PostQueryOptions } from '../../types';
 import { dpnsService } from './dpns-service';
 import { unifiedProfileService } from './unified-profile-service';
-import { identifierToBase58, normalizeSDKResponse, RequestDeduplicator, stringToIdentifierBytes, normalizeBytes, createDefaultUser } from './sdk-helpers';
+import { identifierToBase58, normalizeSDKResponse, RequestDeduplicator, identifierStringToDocumentBytes, normalizeBytes, createDefaultUser } from './sdk-helpers';
 import type { EncryptionOptions } from './post-service';
 
 export interface ReplyDocument {
@@ -147,8 +147,8 @@ class ReplyService extends BaseDocumentService<Reply> {
   ): Promise<Reply> {
     const PRIVATE_REPLY_PLACEHOLDER = '🔒';
     const data: Record<string, unknown> = {
-      parentId: stringToIdentifierBytes(parentId),
-      parentOwnerId: stringToIdentifierBytes(parentOwnerId),
+      parentId: identifierStringToDocumentBytes(parentId),
+      parentOwnerId: identifierStringToDocumentBytes(parentOwnerId),
     };
 
     // Handle encryption if provided

--- a/lib/services/repost-service.ts
+++ b/lib/services/repost-service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { YAPPR_CONTRACT_ID } from '../constants';
 import { stateTransitionService } from './state-transition-service';
-import { stringToIdentifierBytes, normalizeSDKResponse, identifierToBase58 } from './sdk-helpers';
+import { identifierStringToDocumentBytes, normalizeSDKResponse, identifierToBase58 } from './sdk-helpers';
 import { paginateFetchAll } from './pagination-utils';
 
 /**
@@ -83,13 +83,13 @@ class RepostService {
       // Build document data - a post with empty content + quotedPostId
       const documentData: Record<string, unknown> = {
         content: '',  // Empty content marks this as a pure repost
-        quotedPostId: stringToIdentifierBytes(postId),
+        quotedPostId: identifierStringToDocumentBytes(postId),
         language: language,  // Required field
       };
 
       // Add quotedPostOwnerId if provided (for notification queries)
       if (postOwnerId) {
-        documentData.quotedPostOwnerId = stringToIdentifierBytes(postOwnerId);
+        documentData.quotedPostOwnerId = identifierStringToDocumentBytes(postOwnerId);
       }
 
       // Use state transition service for creation

--- a/lib/services/saved-address-service.ts
+++ b/lib/services/saved-address-service.ts
@@ -175,12 +175,12 @@ class SavedAddressService extends BaseDocumentService<InternalSavedAddressDocume
     if (existingDoc) {
       // Update existing document
       await this.update(existingDoc.id, userId, {
-        encryptedPayload: Array.from(encryptedPayload)
+        encryptedPayload
       });
     } else {
       // Create new document
       await this.create(userId, {
-        encryptedPayload: Array.from(encryptedPayload)
+        encryptedPayload
       });
     }
   }

--- a/lib/services/sdk-helpers.ts
+++ b/lib/services/sdk-helpers.ts
@@ -1,9 +1,16 @@
 import { logger } from '@/lib/logger';
 /**
- * SDK helper utilities for working with the v3 EvoSDK
+ * SDK helper utilities for working with the v3 EvoSDK.
  *
- * The v3 SDK returns Map<Identifier, Document> from queries.
- * This helper converts that to a simple array of document data.
+ * Two Platform paths matter here:
+ * - Typed document writes (`new Document(...)`, `sdk.documents.replace(...)`) should receive
+ *   binary properties as `Uint8Array`.
+ * - Raw document queries (`sdk.documents.query(...)`) receive plain query JSON, so operand
+ *   shape depends on the contract field: identifier-like fields use their base58 string form,
+ *   while ordinary `byteArray: true` fields may need an explicit binary encoding.
+ *
+ * The v3 SDK returns `Map<Identifier, Document>` from queries. These helpers normalize that
+ * response shape into plain document objects and keep the write/query byte rules explicit.
  */
 
 import type { EvoSDK } from '@dashevo/evo-sdk';
@@ -17,11 +24,11 @@ import bs58 from 'bs58';
 export type { DocumentWhereClause, DocumentOrderByClause };
 
 /**
- * Convert any identifier value to a base58 string.
+ * Convert any identifier-like value to a base58 string.
  *
- * SDK v3 toJSON() returns different formats:
+ * Query results and `Document#toJSON()` can surface identifier bytes in different forms:
  * - System fields ($id, $ownerId): base58 strings
- * - Byte array fields (postId, replyToPostId, etc): base64 strings
+ * - Identifier-like document fields (postId, replyToPostId, etc): base64 strings or byte arrays
  *
  * This function normalizes both to base58 for consistent handling.
  */
@@ -97,8 +104,8 @@ export function identifierToBase58(value: unknown): string | null {
 }
 
 /**
- * Convert a base58 string to Uint8Array for SDK queries
- * Returns null if the value is invalid
+ * Decode a base58 identifier string into raw bytes.
+ * Returns null if the value is invalid.
  */
 export function base58ToBytes(value: string): Uint8Array | null {
   if (!value || typeof value !== 'string') return null;
@@ -109,7 +116,12 @@ export function base58ToBytes(value: string): Uint8Array | null {
   }
 }
 
-export function requireIdentifierBytes(id: string, fieldName: string): Uint8Array {
+/**
+ * Typed document write helper for required identifier-like fields.
+ *
+ * Use this when building `Document.properties` for create/update/replace paths.
+ */
+export function requireDocumentIdentifierBytes(id: string, fieldName: string): Uint8Array {
   const bytes = base58ToBytes(id)
   if (!bytes || bytes.length !== 32) {
     throw new Error(`Invalid ${fieldName}: expected base58 identifier`)
@@ -118,8 +130,17 @@ export function requireIdentifierBytes(id: string, fieldName: string): Uint8Arra
 }
 
 /**
- * Convert an array of identifier strings to array of Uint8Array
- * For use in 'in' queries on system identifier fields ($id, $ownerId)
+ * Backwards-compatible alias for older call sites.
+ * Prefer `requireDocumentIdentifierBytes` in new code so the typed-write intent stays obvious.
+ */
+export const requireIdentifierBytes = requireDocumentIdentifierBytes
+
+/**
+ * Convert an array of identifier strings to raw bytes.
+ *
+ * This is for low-level binary handling only. Raw queries on system identifier fields usually
+ * pass the base58 strings directly (`$id`, `$ownerId`, or identifier-typed custom fields).
+ *
  * Handles base58, base64, and hex formats. Filters out invalid values.
  */
 export function base58ArrayToBytes(values: string[]): Uint8Array[] {
@@ -313,8 +334,10 @@ export interface QueryDocumentsOptions {
 }
 
 /**
- * Query documents and return as an array of plain objects
- * Handles the v3 SDK Map response format
+ * Query documents and return an array of plain objects.
+ *
+ * This is the raw `sdk.documents.query` path. It does not rewrite `where` operands; callers are
+ * responsible for supplying the contract-appropriate shape for each queried field.
  */
 export async function queryDocuments(
   sdk: EvoSDK,
@@ -414,17 +437,54 @@ export function normalizeSDKResponse(response: unknown): Record<string, unknown>
 }
 
 /**
- * Convert a base58 string to a byte array for SDK document fields.
- * Returns an Array<number> instead of Uint8Array because the SDK
- * serializes Uint8Array incorrectly.
+ * Convert a base58 identifier string into raw bytes for typed `Document.properties`.
+ *
+ * Use this for create/update flows that end up in `new Document(...)` or
+ * `sdk.documents.replace(...)`.
  */
-export function stringToIdentifierBytes(value: string): number[] {
-  return Array.from(bs58.decode(value));
+export function identifierStringToDocumentBytes(value: string): Uint8Array {
+  return bs58.decode(value);
+}
+
+/**
+ * Legacy helper for plain-object paths that still need JSON-serializable byte arrays.
+ *
+ * Prefer `identifierStringToDocumentBytes` for typed document writes.
+ */
+export function identifierStringToLegacyNumberArray(value: string): number[] {
+  return Array.from(identifierStringToDocumentBytes(value));
+}
+
+/**
+ * Encode raw bytes for ordinary `byteArray: true` query operands.
+ *
+ * Yappr uses base64 for these raw-query comparisons because `sdk.documents.query(...)` receives
+ * plain JSON, and ordinary byte-array fields commonly surface as base64 in `toJSON()` output.
+ * Identifier-like fields should stay in their base58 string form instead.
+ */
+export function bytesToBase64QueryOperand(value: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value).toString('base64');
+  }
+
+  let binary = '';
+  for (let i = 0; i < value.length; i++) {
+    binary += String.fromCharCode(value[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Convert a base58 identifier string into the base64 operand used by raw queries on ordinary
+ * byte-array fields that store identifier bytes but are not modeled as identifier-typed fields.
+ */
+export function identifierStringToBase64QueryOperand(value: string): string {
+  return bytesToBase64QueryOperand(identifierStringToDocumentBytes(value));
 }
 
 /**
  * Base document fields returned by all SDK documents.
- * Used by transformDocumentWithField to provide consistent structure.
+ * Used by transformDocumentWithField for documents with one identifier-like field.
  */
 export interface BaseDocumentFields {
   $id: string;
@@ -433,13 +493,13 @@ export interface BaseDocumentFields {
 }
 
 /**
- * Transform a raw SDK document into a typed document with a single byte array field.
+ * Transform a raw SDK document into a typed document with a single identifier-like field.
  *
  * This consolidates the repeated pattern across like, bookmark, repost, and follow services
  * where documents have system fields ($id, $ownerId, $createdAt) plus one identifier field.
  *
  * @param doc - Raw document from SDK (may have nested .data or direct fields)
- * @param fieldName - Name of the byte array field to extract and convert (e.g., 'postId', 'followingId')
+ * @param fieldName - Name of the identifier-like field to extract and convert (e.g., 'postId', 'followingId')
  * @param serviceName - Service name for error logging
  * @returns Document with base fields and the converted identifier field
  */

--- a/lib/services/shipping-zone-service.ts
+++ b/lib/services/shipping-zone-service.ts
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
 
 import { BaseDocumentService } from './document-service';
 import { YAPPR_STOREFRONT_CONTRACT_ID, STOREFRONT_DOCUMENT_TYPES } from '../constants';
-import { identifierToBase58, stringToIdentifierBytes } from './sdk-helpers';
+import { identifierToBase58, identifierStringToDocumentBytes } from './sdk-helpers';
 import type {
   ShippingZone,
   ShippingZoneDocument,
@@ -108,7 +108,7 @@ class ShippingZoneService extends BaseDocumentService<ShippingZone> {
     }
   ): Promise<ShippingZone> {
     const documentData: Record<string, unknown> = {
-      storeId: stringToIdentifierBytes(storeId),
+      storeId: identifierStringToDocumentBytes(storeId),
       name: data.name,
       rateType: data.rateType
     };
@@ -148,7 +148,7 @@ class ShippingZoneService extends BaseDocumentService<ShippingZone> {
     }
 
     const documentData: Record<string, unknown> = {
-      storeId: stringToIdentifierBytes(storeId),
+      storeId: identifierStringToDocumentBytes(storeId),
       name: data.name ?? existing.name,
       rateType: data.rateType ?? existing.rateType
     };

--- a/lib/services/state-transition-service.ts
+++ b/lib/services/state-transition-service.ts
@@ -268,6 +268,9 @@ class StateTransitionService {
   /**
    * Create a document with idempotent retry via ST byte caching.
    *
+   * This is the typed write path: `documentData` should already use `Uint8Array` for binary
+   * fields before it is wrapped in a `Document`.
+   *
    * Instead of using sdk.documents.create() (which atomically builds,
    * signs, broadcasts, and waits — bumping the nonce each time), we:
    *
@@ -311,7 +314,7 @@ class StateTransitionService {
 
       logger.info(`Using signing key id=${identityKey.keyId} with security level ${identityKey.securityLevel}`);
 
-      // Build the Document
+      // Build the typed Document. Binary fields remain Uint8Array on this path.
       const document = await documentBuilderService.buildDocumentForCreate(
         contractId,
         documentType,
@@ -537,7 +540,8 @@ class StateTransitionService {
   }
 
   /**
-   * Update a document using the typed API
+   * Update a document using the typed API.
+   * `documentData` should already use `Uint8Array` for binary fields.
    */
   async updateDocument(
     contractId: string,

--- a/lib/services/store-item-service.ts
+++ b/lib/services/store-item-service.ts
@@ -7,7 +7,7 @@
 
 import { BaseDocumentService } from './document-service';
 import { YAPPR_STOREFRONT_CONTRACT_ID, STOREFRONT_DOCUMENT_TYPES } from '../constants';
-import { identifierToBase58, stringToIdentifierBytes, type DocumentWhereClause } from './sdk-helpers';
+import { identifierToBase58, identifierStringToDocumentBytes, type DocumentWhereClause } from './sdk-helpers';
 import { parseJsonArray, parseJsonObject } from '../utils/json-parsing';
 import type {
   StoreItem,
@@ -156,7 +156,7 @@ class StoreItemService extends BaseDocumentService<StoreItem> {
     }
   ): Promise<StoreItem> {
     const documentData: Record<string, unknown> = {
-      storeId: stringToIdentifierBytes(storeId),
+      storeId: identifierStringToDocumentBytes(storeId),
       title: data.title,
       status: data.status || 'active'
     };
@@ -208,7 +208,7 @@ class StoreItemService extends BaseDocumentService<StoreItem> {
     }
 
     const documentData: Record<string, unknown> = {
-      storeId: stringToIdentifierBytes(storeId),
+      storeId: identifierStringToDocumentBytes(storeId),
       title: data.title ?? existing.title,
       status: data.status ?? existing.status
     };

--- a/lib/services/store-order-service.ts
+++ b/lib/services/store-order-service.ts
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
 
 import { BaseDocumentService } from './document-service';
 import { YAPPR_STOREFRONT_CONTRACT_ID, STOREFRONT_DOCUMENT_TYPES } from '../constants';
-import { identifierToBase58, stringToIdentifierBytes, toUint8Array } from './sdk-helpers';
+import { identifierToBase58, identifierStringToDocumentBytes, toUint8Array } from './sdk-helpers';
 import { privateFeedCryptoService } from './private-feed-crypto-service';
 import type {
   StoreOrder,
@@ -114,10 +114,10 @@ class StoreOrderService extends BaseDocumentService<StoreOrder> {
     }
   ): Promise<StoreOrder> {
     const documentData: Record<string, unknown> = {
-      storeId: stringToIdentifierBytes(data.storeId),
-      sellerId: stringToIdentifierBytes(data.sellerId),
-      encryptedPayload: Array.from(data.encryptedPayload),
-      nonce: Array.from(data.nonce)
+      storeId: identifierStringToDocumentBytes(data.storeId),
+      sellerId: identifierStringToDocumentBytes(data.sellerId),
+      encryptedPayload: data.encryptedPayload,
+      nonce: data.nonce
     };
 
     return this.create(buyerId, documentData);

--- a/lib/services/store-review-service.ts
+++ b/lib/services/store-review-service.ts
@@ -7,7 +7,7 @@
 
 import { BaseDocumentService } from './document-service';
 import { YAPPR_STOREFRONT_CONTRACT_ID, STOREFRONT_DOCUMENT_TYPES } from '../constants';
-import { identifierToBase58, stringToIdentifierBytes } from './sdk-helpers';
+import { identifierToBase58, identifierStringToDocumentBytes } from './sdk-helpers';
 import type {
   StoreReview,
   StoreReviewDocument,
@@ -132,9 +132,9 @@ class StoreReviewService extends BaseDocumentService<StoreReview> {
     }
 
     const documentData: Record<string, unknown> = {
-      storeId: stringToIdentifierBytes(data.storeId),
-      orderId: stringToIdentifierBytes(data.orderId),
-      sellerId: stringToIdentifierBytes(data.sellerId),
+      storeId: identifierStringToDocumentBytes(data.storeId),
+      orderId: identifierStringToDocumentBytes(data.orderId),
+      sellerId: identifierStringToDocumentBytes(data.sellerId),
       rating: data.rating
     };
 


### PR DESCRIPTION
## Summary
- standardize Dash Platform SDK helper naming around typed document writes vs raw query operands
- switch typed `Document` create/update paths to use `Uint8Array` for binary fields while keeping raw query encodings explicit
- clean up stale comments and legacy wording around identifier-like fields versus ordinary byte-array fields

## Testing
- `npm run lint` (passes with existing repo warnings)
- `rm -rf .next && npm run build`

This pull request was created by Codex.
