### PR TITLE
feat: add verifiable credit transfer receipts

### DIFF
--- a/app/orders/seller/page.tsx
+++ b/app/orders/seller/page.tsx
@@ -22,11 +22,12 @@ import { useSdk } from '@/contexts/sdk-context'
 import { useSettingsStore } from '@/lib/store'
 import { storeOrderService } from '@/lib/services/store-order-service'
 import { orderStatusService } from '@/lib/services/order-status-service'
+import { creditTransferService } from '@/lib/services/credit-transfer-service'
 import { dpnsService } from '@/lib/services'
 import { getEncryptionKeyBytes } from '@/lib/secure-storage'
 import toast from 'react-hot-toast'
 import { ClipboardIcon } from '@heroicons/react/24/outline'
-import type { StoreOrder, OrderStatusUpdate, OrderStatus, OrderPayload } from '@/lib/types'
+import type { StoreOrder, OrderStatusUpdate, OrderStatus, OrderPayload, CreditTransferReceiptVerification } from '@/lib/types'
 
 /**
  * Decrypt order payload using seller's encryption private key.
@@ -73,6 +74,7 @@ function SellerOrdersPage() {
   const [orderPayloads, setOrderPayloads] = useState<Map<string, OrderPayload>>(new Map())
   const [orderStatuses, setOrderStatuses] = useState<Map<string, OrderStatusUpdate>>(new Map())
   const [buyerUsernames, setBuyerUsernames] = useState<Map<string, string>>(new Map())
+  const [paymentReceiptStatuses, setPaymentReceiptStatuses] = useState<Map<string, CreditTransferReceiptVerification>>(new Map())
   const [isLoading, setIsLoading] = useState(true)
   const [expandedOrder, setExpandedOrder] = useState<string | null>(null)
 
@@ -99,15 +101,31 @@ function SellerOrdersPage() {
 
         // Decrypt order payloads
         const payloadMap = new Map<string, OrderPayload>()
+        const receiptStatusMap = new Map<string, CreditTransferReceiptVerification>()
         await Promise.all(
           sellerOrders.map(async (order) => {
             const payload = await decryptSellerOrderPayload(order, sellerPrivateKey)
             if (payload) {
               payloadMap.set(order.id, payload)
+
+              if (
+                payload.paymentMethod === 'platformCredits' &&
+                payload.creditTransferReceiptId
+              ) {
+                const verification = await creditTransferService.verifyReceipt(
+                  payload.creditTransferReceiptId,
+                  {
+                    expectedRecipientId: order.sellerId,
+                    expectedAmountCredits: payload.paymentAmountCredits,
+                  }
+                )
+                receiptStatusMap.set(order.id, verification)
+              }
             }
           })
         )
         setOrderPayloads(payloadMap)
+        setPaymentReceiptStatuses(receiptStatusMap)
 
         // Load latest status for each order and resolve buyer usernames
         const statusMap = new Map<string, OrderStatusUpdate>()
@@ -215,6 +233,7 @@ function SellerOrdersPage() {
               {orders.map((order, index) => {
                 const status = orderStatuses.get(order.id)
                 const payload = orderPayloads.get(order.id)
+                const paymentReceiptStatus = paymentReceiptStatuses.get(order.id)
                 const isExpanded = expandedOrder === order.id
                 const isUpdating = updateOrderId === order.id
 
@@ -332,19 +351,50 @@ function SellerOrdersPage() {
                             {/* Payment Info */}
                             <div className="p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
                               <p className="text-sm font-medium mb-2">Payment</p>
-                              <p className="text-sm font-mono break-all">{payload.paymentUri}</p>
-                              {payload.txid && (
-                                <p className="text-sm mt-1">
-                                  <span className="text-gray-500">TXID: </span>
-                                  <a
-                                    href={storeOrderService.getPaymentVerificationUrl(payload.txid)}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-yappr-600 hover:underline font-mono"
-                                  >
-                                    {payload.txid.slice(0, 16)}...
-                                  </a>
-                                </p>
+                              {payload.paymentMethod === 'platformCredits' ? (
+                                <>
+                                  <p className="text-sm">
+                                    Platform credits
+                                    {payload.paymentAmountCredits ? ` • ${payload.paymentAmountCredits} credits` : ''}
+                                  </p>
+                                  {payload.creditTransferReceiptId && (
+                                    <p className="text-sm mt-1">
+                                      <span className="text-gray-500">Receipt: </span>
+                                      <span className="font-mono break-all">{payload.creditTransferReceiptId}</span>
+                                    </p>
+                                  )}
+                                  {paymentReceiptStatus && (
+                                    <p className="text-sm mt-1">
+                                      <span className="text-gray-500">Status: </span>
+                                      <span className={
+                                        paymentReceiptStatus.status === 'verified'
+                                          ? 'text-green-700 dark:text-green-300'
+                                          : 'text-blue-700 dark:text-blue-300'
+                                      }>
+                                        {paymentReceiptStatus.status === 'verified' ? 'Verified receipt' : 'Receipt pending'}
+                                      </span>
+                                    </p>
+                                  )}
+                                </>
+                              ) : (
+                                <>
+                                  {payload.paymentUri && (
+                                    <p className="text-sm font-mono break-all">{payload.paymentUri}</p>
+                                  )}
+                                  {payload.txid && (
+                                    <p className="text-sm mt-1">
+                                      <span className="text-gray-500">TXID: </span>
+                                      <a
+                                        href={storeOrderService.getPaymentVerificationUrl(payload.txid)}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-yappr-600 hover:underline font-mono"
+                                      >
+                                        {payload.txid.slice(0, 16)}...
+                                      </a>
+                                    </p>
+                                  )}
+                                </>
                               )}
                             </div>
 

--- a/components/post/post-card.tsx
+++ b/components/post/post-card.tsx
@@ -46,6 +46,7 @@ import { useMentionValidation } from '@/hooks/use-mention-validation'
 import { useMentionRecoveryModal } from '@/hooks/use-mention-recovery-modal'
 import { useDeleteConfirmationModal } from '@/hooks/use-delete-confirmation-modal'
 import { tipService } from '@/lib/services/tip-service'
+import { creditTransferService } from '@/lib/services/credit-transfer-service'
 import { useCanReplyToPrivate } from '@/hooks/use-can-reply-to-private'
 
 // Username loading state: undefined = loading, null = no DPNS, string = username
@@ -330,7 +331,46 @@ export function PostCard({ post, hideAvatar = false, isOwnPost: isOwnPostProp, e
   // Check if this post is a tip and parse tip info
   const tipInfo = useMemo(() => tipService.parseTipContent(post.content), [post.content])
   const isTipPost = !!tipInfo
+  const [tipVerificationStatus, setTipVerificationStatus] = useState<'verified' | 'pending' | 'legacy'>(
+    tipInfo?.verificationStatus || 'legacy'
+  )
   const createdAtLabel = useRelativeTime(post.createdAt)
+
+  useEffect(() => {
+    if (!tipInfo) {
+      return
+    }
+
+    if (!tipInfo.receiptId) {
+      setTipVerificationStatus('legacy')
+      return
+    }
+
+    let cancelled = false
+    setTipVerificationStatus('pending')
+
+    creditTransferService.verifyReceipt(tipInfo.receiptId, {
+      expectedSenderId: post.author.id,
+      expectedRecipientId: post.parentOwnerId,
+      expectedAmountCredits: String(tipInfo.amount),
+      expectedReferenceType: 'tip',
+      expectedReferenceId: post.parentId,
+    })
+      .then((result) => {
+        if (cancelled) return
+        setTipVerificationStatus(result.status === 'verified' ? 'verified' : 'pending')
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          logger.warn('Failed to verify tip receipt', error)
+          setTipVerificationStatus('pending')
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [tipInfo, post.author.id, post.parentId, post.parentOwnerId])
 
   const handleLike = async () => {
     if (hideAvatar) {
@@ -668,29 +708,32 @@ export function PostCard({ post, hideAvatar = false, isOwnPost: isOwnPostProp, e
           </div>
 
           {/* Tip post - show tip badge with recipient and message */}
-          {/* TODO: Remove tooltip once SDK exposes transition IDs for on-chain verification */}
           {isTipPost ? (
             <div className="mt-2">
-              <Tooltip.Provider>
-                <Tooltip.Root>
-                  <Tooltip.Trigger asChild>
-                    <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 text-sm font-medium mb-2 cursor-help">
-                      <CurrencyDollarIcon className="h-4 w-4" />
-                      <span>
-                        Sent a tip of {tipService.formatDash(tipService.creditsToDash(tipInfo.amount))}
-                      </span>
-                    </div>
-                  </Tooltip.Trigger>
-                  <Tooltip.Portal>
-                    <Tooltip.Content
-                      className="bg-gray-800 dark:bg-gray-700 text-white text-xs px-2 py-1 rounded max-w-xs"
-                      sideOffset={5}
-                    >
-                      Unverified - awaiting SDK support
-                    </Tooltip.Content>
-                  </Tooltip.Portal>
-                </Tooltip.Root>
-              </Tooltip.Provider>
+              <div className="flex flex-wrap items-center gap-2 mb-2">
+                <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 text-sm font-medium">
+                  <CurrencyDollarIcon className="h-4 w-4" />
+                  <span>
+                    Sent a tip of {tipService.formatDash(tipService.creditsToDash(tipInfo.amount))}
+                  </span>
+                </div>
+                <div
+                  className={cn(
+                    'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
+                    tipVerificationStatus === 'verified'
+                      ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
+                      : tipVerificationStatus === 'legacy'
+                        ? 'bg-gray-100 dark:bg-neutral-800 text-gray-600 dark:text-gray-300'
+                        : 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                  )}
+                >
+                  {tipVerificationStatus === 'verified'
+                    ? 'Verified'
+                    : tipVerificationStatus === 'legacy'
+                      ? 'Unverified legacy'
+                      : 'Pending'}
+                </div>
+              </div>
               {tipInfo.message && (
                 <PostContent content={tipInfo.message} className="mt-1" />
               )}

--- a/components/post/tip-modal.tsx
+++ b/components/post/tip-modal.tsx
@@ -60,6 +60,8 @@ export function TipModal() {
   const [activeTab, setActiveTab] = useState<PaymentTab>('credits')
   const [selectedQrPayment, setSelectedQrPayment] = useState<ParsedPaymentUri | null>(null)
   const [showQrDialog, setShowQrDialog] = useState(false)
+  const [receiptId, setReceiptId] = useState<string | null>(null)
+  const [verificationStatus, setVerificationStatus] = useState<'verified' | 'pending' | null>(null)
 
   // Transfer key persistence
   const [keySource, setKeySource] = useState<KeySource>(null)
@@ -113,6 +115,8 @@ export function TipModal() {
       setShowQrDialog(false)
       setKeySource(null)
       usedTransferKeyRef.current = null
+      setReceiptId(null)
+      setVerificationStatus(null)
     }
   }, [isOpen])
 
@@ -197,6 +201,9 @@ export function TipModal() {
     setTransferKey('')
 
     if (result.success) {
+      setReceiptId(result.receiptId || null)
+      setVerificationStatus(result.verificationStatus || null)
+
       // Refresh balance display and persist to auth context
       identityService.getBalance(user.identityId)
         .then(b => setBalance(b.confirmed))
@@ -273,6 +280,16 @@ export function TipModal() {
   const handleCloseQrDialog = () => {
     setShowQrDialog(false)
     setSelectedQrPayment(null)
+  }
+
+  const handleCopyReceiptId = async () => {
+    if (!receiptId) return
+
+    try {
+      await navigator.clipboard.writeText(receiptId)
+    } catch (copyError) {
+      logger.error('Failed to copy receipt ID:', copyError)
+    }
   }
 
 
@@ -574,6 +591,27 @@ export function TipModal() {
                       </p>
                     </div>
 
+                    {receiptId && (
+                      <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 bg-gray-50 dark:bg-neutral-800">
+                        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                          Receipt {verificationStatus === 'verified' ? 'verified' : 'pending'}
+                        </p>
+                        <p className="text-xs text-gray-500 mt-1">
+                          {verificationStatus === 'verified'
+                            ? 'This transfer has a receipt that can be verified from the tip reply.'
+                            : 'The receipt ID is fixed now and the final proof check may still be catching up.'}
+                        </p>
+                        <div className="mt-2 flex items-center gap-2">
+                          <code className="flex-1 text-xs break-all px-2 py-1 rounded bg-white dark:bg-neutral-900 border border-gray-200 dark:border-gray-700">
+                            {receiptId}
+                          </code>
+                          <Button type="button" variant="outline" size="sm" onClick={handleCopyReceiptId}>
+                            Copy
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+
                     <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg p-4">
                       <div className="flex items-start gap-3">
                         <BookmarkIcon className="h-5 w-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
@@ -620,6 +658,26 @@ export function TipModal() {
                       <p className="text-sm text-gray-500">
                         New balance: {tipService.formatDash(tipService.creditsToDash(balance))}
                       </p>
+                    )}
+                    {receiptId && (
+                      <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 bg-gray-50 dark:bg-neutral-800 text-left">
+                        <p className="text-sm font-medium">
+                          Receipt {verificationStatus === 'verified' ? 'verified' : 'pending'}
+                        </p>
+                        <p className="text-xs text-gray-500 mt-1">
+                          {verificationStatus === 'verified'
+                            ? 'This receipt can be shared or re-opened from the tip reply.'
+                            : 'This receipt ID is stable even if final verification is still pending.'}
+                        </p>
+                        <div className="mt-2 flex items-center gap-2">
+                          <code className="flex-1 text-xs break-all px-2 py-1 rounded bg-white dark:bg-neutral-900 border border-gray-200 dark:border-gray-700">
+                            {receiptId}
+                          </code>
+                          <Button type="button" variant="outline" size="sm" onClick={handleCopyReceiptId}>
+                            Copy
+                          </Button>
+                        </div>
+                      </div>
                     )}
                     <Button onClick={close} className="w-full">
                       Done

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation'
 import { PlatformAuthController, type AuthUser as PlatformAuthUser, type PlatformAuthIntent } from 'platform-auth'
 import { createYapprPlatformAuthDependencies } from '@/lib/auth/platform-auth-adapters'
 import { extractErrorMessage, isAlreadyExistsError } from '@/lib/error-utils'
+import { creditTransferService } from '@/lib/services/credit-transfer-service'
 import { useUsernameModal } from '@/hooks/use-username-modal'
 
 export interface AuthUser {
@@ -123,6 +124,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       controller.dispose()
     }
   }, [controller])
+
+  useEffect(() => {
+    const identityId = controllerState.user?.identityId
+    if (!identityId || typeof window === 'undefined') {
+      return
+    }
+
+    creditTransferService.recoverPendingTransfers(identityId).catch((error) => {
+      logger.warn('Auth: Failed to recover pending credit transfers', error)
+    })
+  }, [controllerState.user?.identityId])
 
   const applyIntent = useCallback(async (intent: PlatformAuthIntent): Promise<void> => {
     switch (intent.kind) {

--- a/contracts/yappr-payment-receipt-contract.json
+++ b/contracts/yappr-payment-receipt-contract.json
@@ -1,0 +1,94 @@
+{
+  "creditTransferReceipt": {
+    "type": "object",
+    "indices": [
+      {
+        "name": "transitionHash",
+        "unique": true,
+        "properties": [
+          {
+            "transitionHash": "asc"
+          }
+        ]
+      },
+      {
+        "name": "recipientAndTime",
+        "properties": [
+          {
+            "recipientId": "asc"
+          },
+          {
+            "$createdAt": "asc"
+          }
+        ]
+      },
+      {
+        "name": "senderAndTime",
+        "properties": [
+          {
+            "$ownerId": "asc"
+          },
+          {
+            "$createdAt": "asc"
+          }
+        ]
+      }
+    ],
+    "mutable": false,
+    "required": [
+      "$createdAt",
+      "recipientId",
+      "amountCredits",
+      "transitionHash",
+      "transitionBytes"
+    ],
+    "properties": {
+      "recipientId": {
+        "type": "array",
+        "maxItems": 32,
+        "minItems": 32,
+        "position": 0,
+        "byteArray": true,
+        "description": "Identity ID of the credit transfer recipient",
+        "contentMediaType": "application/x.dash.dpp.identifier"
+      },
+      "amountCredits": {
+        "type": "string",
+        "position": 1,
+        "maxLength": 32,
+        "description": "Transfer amount in credits serialized as a base-10 string"
+      },
+      "transitionHash": {
+        "type": "string",
+        "position": 2,
+        "maxLength": 128,
+        "description": "Hash of the signed state transition"
+      },
+      "transitionBytes": {
+        "type": "array",
+        "maxItems": 4096,
+        "minItems": 1,
+        "position": 3,
+        "byteArray": true,
+        "description": "Serialized signed IdentityCreditTransfer bytes"
+      },
+      "referenceType": {
+        "type": "string",
+        "position": 4,
+        "maxLength": 50,
+        "description": "Optional application-level reference type such as tip or storeOrder"
+      },
+      "referenceId": {
+        "type": "array",
+        "maxItems": 32,
+        "minItems": 32,
+        "position": 5,
+        "byteArray": true,
+        "description": "Optional application-level reference identifier",
+        "contentMediaType": "application/x.dash.dpp.identifier"
+      }
+    },
+    "description": "Receipt document for a recipient-verifiable Platform credit transfer",
+    "additionalProperties": false
+  }
+}

--- a/contracts/yappr-payment-receipt-contract.json
+++ b/contracts/yappr-payment-receipt-contract.json
@@ -59,10 +59,12 @@
         "description": "Transfer amount in credits serialized as a base-10 string"
       },
       "transitionHash": {
-        "type": "string",
+        "type": "array",
+        "maxItems": 32,
+        "minItems": 32,
         "position": 2,
-        "maxLength": 128,
-        "description": "Hash of the signed state transition"
+        "byteArray": true,
+        "description": "Binary hash of the signed state transition"
       },
       "transitionBytes": {
         "type": "array",

--- a/contracts/yappr-payment-receipt-contract.json
+++ b/contracts/yappr-payment-receipt-contract.json
@@ -53,10 +53,11 @@
         "contentMediaType": "application/x.dash.dpp.identifier"
       },
       "amountCredits": {
-        "type": "string",
+        "type": "integer",
         "position": 1,
-        "maxLength": 32,
-        "description": "Transfer amount in credits serialized as a base-10 string"
+        "minimum": 0,
+        "maximum": 9007199254740991,
+        "description": "Transfer amount in credits"
       },
       "transitionHash": {
         "type": "array",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,6 +16,7 @@ export const KEY_EXCHANGE_CONTRACT_ID = process.env.NEXT_PUBLIC_KEY_EXCHANGE_CON
 export const YAPPR_VAULT_CONTRACT_ID = process.env.NEXT_PUBLIC_YAPPR_VAULT_CONTRACT_ID || '7RQoHtVZaRZDSrR22s8KcbCJmwSwetJHBcFjx6FJdkJD' // Testnet - Vault contract (contract-bound encryption keys + encrypted storage)
 export const YAPPR_AUTH_VAULT_CONTRACT_ID = process.env.NEXT_PUBLIC_YAPPR_AUTH_VAULT_CONTRACT_ID || '64RTgHjGXhtiN9t5S4u6hVDps7oHuTBaaHrQEFYcxt9M'
 export const YAPPR_BLOG_CONTRACT_ID = '9jfarXPwRoKXK4v2JBDaiFg3j78diQuLnHMyVqBZfZNc' // Testnet - Blog contract v4 (BlockNote 0.47 upgrade)
+export const YAPPR_PAYMENT_RECEIPT_CONTRACT_ID = process.env.NEXT_PUBLIC_YAPPR_PAYMENT_RECEIPT_CONTRACT_ID || ''
 export const BLOG_CHUNK_SIZE = 5120         // 5 KiB — platform max_field_value_size
 export const BLOG_MAX_CHUNKS = 4            // Number of data fields in contract (data0–data3)
 export const BLOG_POST_SIZE_LIMIT = 16384   // Max total compressed content (leaves headroom within 4 × 5120 = 20KB)
@@ -84,6 +85,10 @@ export const STOREFRONT_DOCUMENT_TYPES = {
   ORDER_STATUS_UPDATE: 'orderStatusUpdate',
   STORE_REVIEW: 'storeReview',
   SAVED_ADDRESS: 'savedAddress'
+} as const
+
+export const PAYMENT_RECEIPT_DOCUMENT_TYPES = {
+  CREDIT_TRANSFER_RECEIPT: 'creditTransferReceipt'
 } as const
 
 // DPNS

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,7 +16,7 @@ export const KEY_EXCHANGE_CONTRACT_ID = process.env.NEXT_PUBLIC_KEY_EXCHANGE_CON
 export const YAPPR_VAULT_CONTRACT_ID = process.env.NEXT_PUBLIC_YAPPR_VAULT_CONTRACT_ID || '7RQoHtVZaRZDSrR22s8KcbCJmwSwetJHBcFjx6FJdkJD' // Testnet - Vault contract (contract-bound encryption keys + encrypted storage)
 export const YAPPR_AUTH_VAULT_CONTRACT_ID = process.env.NEXT_PUBLIC_YAPPR_AUTH_VAULT_CONTRACT_ID || '64RTgHjGXhtiN9t5S4u6hVDps7oHuTBaaHrQEFYcxt9M'
 export const YAPPR_BLOG_CONTRACT_ID = '9jfarXPwRoKXK4v2JBDaiFg3j78diQuLnHMyVqBZfZNc' // Testnet - Blog contract v4 (BlockNote 0.47 upgrade)
-export const YAPPR_PAYMENT_RECEIPT_CONTRACT_ID = process.env.NEXT_PUBLIC_YAPPR_PAYMENT_RECEIPT_CONTRACT_ID || ''
+export const YAPPR_PAYMENT_RECEIPT_CONTRACT_ID = process.env.NEXT_PUBLIC_YAPPR_PAYMENT_RECEIPT_CONTRACT_ID || '3fuTozsJrrft5cqRrg2GBxTrXUsFBK3vnkZXnK5eVCst' // Testnet - Payment receipt contract
 export const BLOG_CHUNK_SIZE = 5120         // 5 KiB — platform max_field_value_size
 export const BLOG_MAX_CHUNKS = 4            // Number of data fields in contract (data0–data3)
 export const BLOG_POST_SIZE_LIMIT = 16384   // Max total compressed content (leaves headroom within 4 × 5120 = 20KB)

--- a/lib/services/credit-transfer-receipt-service.ts
+++ b/lib/services/credit-transfer-receipt-service.ts
@@ -1,7 +1,44 @@
 import { BaseDocumentService } from './document-service'
 import { PAYMENT_RECEIPT_DOCUMENT_TYPES, YAPPR_PAYMENT_RECEIPT_CONTRACT_ID } from '../constants'
-import { identifierToBase58, identifierStringToDocumentBytes, toUint8Array } from './sdk-helpers'
+import bs58 from 'bs58'
+import {
+  base64ToBytes,
+  bytesToBase64QueryOperand,
+  identifierToBase58,
+  identifierStringToDocumentBytes,
+  toUint8Array,
+} from './sdk-helpers'
 import type { CreditTransferReceipt, CreditTransferReceiptDocument, CreditTransferReceiptReferenceType } from '@/lib/types'
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+function transitionHashStringToBytes(value: string): Uint8Array {
+  const normalized = value.trim()
+
+  if (/^[0-9a-fA-F]{64}$/.test(normalized)) {
+    const bytes = new Uint8Array(normalized.length / 2)
+    for (let index = 0; index < normalized.length; index += 2) {
+      bytes[index / 2] = parseInt(normalized.slice(index, index + 2), 16)
+    }
+    return bytes
+  }
+
+  if (normalized.includes('+') || normalized.includes('/') || normalized.endsWith('=')) {
+    const bytes = base64ToBytes(normalized)
+    if (bytes.length === 32) {
+      return bytes
+    }
+  }
+
+  const decoded = bs58.decode(normalized)
+  if (decoded.length !== 32) {
+    throw new Error('Invalid transition hash: expected 32 bytes')
+  }
+
+  return decoded
+}
 
 class CreditTransferReceiptService extends BaseDocumentService<CreditTransferReceipt> {
   constructor() {
@@ -27,7 +64,7 @@ class CreditTransferReceiptService extends BaseDocumentService<CreditTransferRec
       createdAt: new Date((doc.$createdAt || doc.createdAt) as number),
       recipientId: identifierToBase58(data.recipientId) || '',
       amountCredits: data.amountCredits,
-      transitionHash: data.transitionHash,
+      transitionHash: bytesToHex(toUint8Array(data.transitionHash) || new Uint8Array()),
       transitionBytes: toUint8Array(data.transitionBytes) || new Uint8Array(),
       referenceType: data.referenceType,
       referenceId: data.referenceId ? identifierToBase58(data.referenceId) || undefined : undefined,
@@ -41,9 +78,10 @@ class CreditTransferReceiptService extends BaseDocumentService<CreditTransferRec
 
   async getByTransitionHash(transitionHash: string): Promise<CreditTransferReceipt | null> {
     this.ensureConfigured()
+    const transitionHashBytes = transitionHashStringToBytes(transitionHash)
 
     const { documents } = await this.query({
-      where: [['transitionHash', '==', transitionHash]],
+      where: [['transitionHash', '==', bytesToBase64QueryOperand(transitionHashBytes)]],
       orderBy: [['transitionHash', 'asc']],
       limit: 1,
     })
@@ -78,7 +116,7 @@ class CreditTransferReceiptService extends BaseDocumentService<CreditTransferRec
     const documentData: Record<string, unknown> = {
       recipientId: identifierStringToDocumentBytes(data.recipientId),
       amountCredits: data.amountCredits,
-      transitionHash: data.transitionHash,
+      transitionHash: transitionHashStringToBytes(data.transitionHash),
       transitionBytes: data.transitionBytes,
     }
 

--- a/lib/services/credit-transfer-receipt-service.ts
+++ b/lib/services/credit-transfer-receipt-service.ts
@@ -40,6 +40,14 @@ function transitionHashStringToBytes(value: string): Uint8Array {
   return decoded
 }
 
+function amountCreditsToDocumentInteger(value: bigint): number {
+  const amount = Number(value)
+  if (!Number.isSafeInteger(amount) || amount < 0) {
+    throw new Error('Invalid amountCredits: expected a non-negative safe integer for receipt storage')
+  }
+  return amount
+}
+
 class CreditTransferReceiptService extends BaseDocumentService<CreditTransferReceipt> {
   constructor() {
     super(PAYMENT_RECEIPT_DOCUMENT_TYPES.CREDIT_TRANSFER_RECEIPT, YAPPR_PAYMENT_RECEIPT_CONTRACT_ID)
@@ -63,7 +71,7 @@ class CreditTransferReceiptService extends BaseDocumentService<CreditTransferRec
       ownerId: (doc.$ownerId || doc.ownerId) as string,
       createdAt: new Date((doc.$createdAt || doc.createdAt) as number),
       recipientId: identifierToBase58(data.recipientId) || '',
-      amountCredits: data.amountCredits,
+      amountCredits: BigInt(data.amountCredits),
       transitionHash: bytesToHex(toUint8Array(data.transitionHash) || new Uint8Array()),
       transitionBytes: toUint8Array(data.transitionBytes) || new Uint8Array(),
       referenceType: data.referenceType,
@@ -94,7 +102,7 @@ class CreditTransferReceiptService extends BaseDocumentService<CreditTransferRec
     data: {
       receiptId: string
       recipientId: string
-      amountCredits: string
+      amountCredits: bigint
       transitionHash: string
       transitionBytes: Uint8Array
       referenceType?: CreditTransferReceiptReferenceType
@@ -115,7 +123,7 @@ class CreditTransferReceiptService extends BaseDocumentService<CreditTransferRec
 
     const documentData: Record<string, unknown> = {
       recipientId: identifierStringToDocumentBytes(data.recipientId),
-      amountCredits: data.amountCredits,
+      amountCredits: amountCreditsToDocumentInteger(data.amountCredits),
       transitionHash: transitionHashStringToBytes(data.transitionHash),
       transitionBytes: data.transitionBytes,
     }

--- a/lib/services/credit-transfer-receipt-service.ts
+++ b/lib/services/credit-transfer-receipt-service.ts
@@ -1,0 +1,98 @@
+import { BaseDocumentService } from './document-service'
+import { PAYMENT_RECEIPT_DOCUMENT_TYPES, YAPPR_PAYMENT_RECEIPT_CONTRACT_ID } from '../constants'
+import { identifierToBase58, identifierStringToDocumentBytes, toUint8Array } from './sdk-helpers'
+import type { CreditTransferReceipt, CreditTransferReceiptDocument, CreditTransferReceiptReferenceType } from '@/lib/types'
+
+class CreditTransferReceiptService extends BaseDocumentService<CreditTransferReceipt> {
+  constructor() {
+    super(PAYMENT_RECEIPT_DOCUMENT_TYPES.CREDIT_TRANSFER_RECEIPT, YAPPR_PAYMENT_RECEIPT_CONTRACT_ID)
+  }
+
+  isConfigured(): boolean {
+    return Boolean(YAPPR_PAYMENT_RECEIPT_CONTRACT_ID)
+  }
+
+  private ensureConfigured(): void {
+    if (!this.isConfigured()) {
+      throw new Error('Payment receipt contract is not configured. Set NEXT_PUBLIC_YAPPR_PAYMENT_RECEIPT_CONTRACT_ID before using receipt-backed credit transfers.')
+    }
+  }
+
+  protected transformDocument(doc: Record<string, unknown>): CreditTransferReceipt {
+    const data = (doc.data || doc) as CreditTransferReceiptDocument
+
+    return {
+      id: (doc.$id || doc.id) as string,
+      ownerId: (doc.$ownerId || doc.ownerId) as string,
+      createdAt: new Date((doc.$createdAt || doc.createdAt) as number),
+      recipientId: identifierToBase58(data.recipientId) || '',
+      amountCredits: data.amountCredits,
+      transitionHash: data.transitionHash,
+      transitionBytes: toUint8Array(data.transitionBytes) || new Uint8Array(),
+      referenceType: data.referenceType,
+      referenceId: data.referenceId ? identifierToBase58(data.referenceId) || undefined : undefined,
+    }
+  }
+
+  async getById(receiptId: string): Promise<CreditTransferReceipt | null> {
+    this.ensureConfigured()
+    return this.get(receiptId)
+  }
+
+  async getByTransitionHash(transitionHash: string): Promise<CreditTransferReceipt | null> {
+    this.ensureConfigured()
+
+    const { documents } = await this.query({
+      where: [['transitionHash', '==', transitionHash]],
+      orderBy: [['transitionHash', 'asc']],
+      limit: 1,
+    })
+
+    return documents[0] || null
+  }
+
+  async createReceipt(
+    ownerId: string,
+    data: {
+      receiptId: string
+      recipientId: string
+      amountCredits: string
+      transitionHash: string
+      transitionBytes: Uint8Array
+      referenceType?: CreditTransferReceiptReferenceType
+      referenceId?: string
+    }
+  ): Promise<CreditTransferReceipt> {
+    this.ensureConfigured()
+
+    const existingById = await this.getById(data.receiptId)
+    if (existingById) {
+      return existingById
+    }
+
+    const existingByHash = await this.getByTransitionHash(data.transitionHash)
+    if (existingByHash) {
+      return existingByHash
+    }
+
+    const documentData: Record<string, unknown> = {
+      recipientId: identifierStringToDocumentBytes(data.recipientId),
+      amountCredits: data.amountCredits,
+      transitionHash: data.transitionHash,
+      transitionBytes: data.transitionBytes,
+    }
+
+    if (data.referenceType) {
+      documentData.referenceType = data.referenceType
+    }
+    if (data.referenceId) {
+      documentData.referenceId = identifierStringToDocumentBytes(data.referenceId)
+    }
+
+    return this.createWithOptions(ownerId, documentData, {
+      documentId: data.receiptId,
+    })
+  }
+}
+
+export const creditTransferReceiptService = new CreditTransferReceiptService()

--- a/lib/services/credit-transfer-service.ts
+++ b/lib/services/credit-transfer-service.ts
@@ -1,0 +1,651 @@
+import bs58 from 'bs58'
+import * as EvoSdkModule from '@dashevo/evo-sdk'
+import {
+  IdentityCreditTransfer,
+  PrivateKey,
+  StateTransition,
+} from '@dashevo/evo-sdk'
+import type { IdentityPublicKey as WasmIdentityPublicKey } from '@dashevo/wasm-sdk/compressed'
+
+import { logger } from '@/lib/logger'
+import { extractErrorMessage, isAlreadyExistsError, isNonFatalWaitError, isTimeoutError } from '@/lib/error-utils'
+import type {
+  CreditTransferReceiptReferenceType,
+  CreditTransferReceiptVerification,
+} from '@/lib/types'
+import { findMatchingKeyIndex, type IdentityPublicKeyInfo } from '@/lib/crypto/keys'
+import { getEvoSdk } from './evo-sdk-service'
+import { identityService } from './identity-service'
+import { KeyPurpose } from './signer-service'
+import { creditTransferReceiptService } from './credit-transfer-receipt-service'
+
+export interface CreditTransferOptions {
+  senderId: string
+  recipientId: string
+  amountCredits: bigint
+  transferKeyWif: string
+  keyId?: number
+  referenceType?: CreditTransferReceiptReferenceType
+  referenceId?: string
+}
+
+export interface CreditTransferVerificationOptions {
+  expectedSenderId?: string
+  expectedRecipientId?: string
+  expectedAmountCredits?: string
+  expectedReferenceType?: CreditTransferReceiptReferenceType
+  expectedReferenceId?: string
+}
+
+export interface CreditTransferResult {
+  success: boolean
+  transitionHash?: string
+  receiptId?: string
+  receiptConfirmed?: boolean
+  verificationStatus?: 'verified' | 'pending'
+  senderBalance?: bigint
+  recipientBalance?: bigint
+  error?: string
+}
+
+interface PendingCreditTransferEntry {
+  receiptId: string
+  transitionHash: string
+  senderId: string
+  recipientId: string
+  amountCredits: string
+  transitionBytes: string
+  referenceType?: string
+  referenceId?: string
+  cachedAt: number
+}
+
+interface IdentityCreditTransferTransitionFactory {
+  fromObject(obj: {
+    amount: bigint
+    senderId: Uint8Array
+    recipientId: Uint8Array
+    nonce: bigint
+    userFeeIncrease: number
+    signature?: Uint8Array
+    signaturePublicKeyId?: number
+  }): IdentityCreditTransfer
+}
+
+interface VerifiedBalanceTransferLike {
+  __type: 'VerifiedBalanceTransfer'
+  sender: {
+    id: { toString(): string }
+    balance?: bigint
+  }
+  recipient: {
+    id: { toString(): string }
+    balance?: bigint
+  }
+}
+
+const identityCreditTransferTransitionFactory = (
+  EvoSdkModule as unknown as {
+    IdentityCreditTransferTransition: IdentityCreditTransferTransitionFactory
+  }
+).IdentityCreditTransferTransition
+
+function isVerifiedBalanceTransfer(result: unknown): result is VerifiedBalanceTransferLike {
+  if (!result || typeof result !== 'object') {
+    return false
+  }
+
+  const candidate = result as {
+    __type?: unknown
+    sender?: unknown
+    recipient?: unknown
+  }
+
+  return (
+    candidate.__type === 'VerifiedBalanceTransfer' &&
+    candidate.sender !== undefined &&
+    candidate.recipient !== undefined
+  )
+}
+
+const PENDING_TRANSFER_PREFIX = 'yappr:pending-credit-transfer:'
+const PENDING_TRANSFER_MAX_AGE_MS = 24 * 60 * 60 * 1000
+const PENDING_TRANSFER_MAX_ENTRIES = 50
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  const digestInput = Uint8Array.from(bytes).buffer
+  const digest = await crypto.subtle.digest('SHA-256', digestInput)
+  return new Uint8Array(digest)
+}
+
+function pendingTransferKey(transitionHash: string): string {
+  return `${PENDING_TRANSFER_PREFIX}${transitionHash}`
+}
+
+function savePendingTransfer(entry: PendingCreditTransferEntry): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.setItem(pendingTransferKey(entry.transitionHash), JSON.stringify(entry))
+  } catch (error) {
+    logger.warn('Failed to cache pending credit transfer', error)
+  }
+}
+
+function clearPendingTransfer(transitionHash: string): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(pendingTransferKey(transitionHash))
+  } catch {
+    // Ignore cache cleanup errors.
+  }
+}
+
+function cleanupPendingTransfers(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    const now = Date.now()
+    const keys: string[] = []
+    const entries: Array<{ key: string; cachedAt: number }> = []
+
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i)
+      if (key?.startsWith(PENDING_TRANSFER_PREFIX)) {
+        keys.push(key)
+      }
+    }
+
+    for (const key of keys) {
+      const raw = localStorage.getItem(key)
+      if (!raw) continue
+
+      try {
+        const parsed = JSON.parse(raw) as PendingCreditTransferEntry
+        if (!parsed.cachedAt || now - parsed.cachedAt > PENDING_TRANSFER_MAX_AGE_MS) {
+          localStorage.removeItem(key)
+          continue
+        }
+        entries.push({ key, cachedAt: parsed.cachedAt })
+      } catch {
+        localStorage.removeItem(key)
+      }
+    }
+
+    if (entries.length > PENDING_TRANSFER_MAX_ENTRIES) {
+      entries.sort((a, b) => a.cachedAt - b.cachedAt)
+      for (let index = 0; index < entries.length - PENDING_TRANSFER_MAX_ENTRIES; index += 1) {
+        localStorage.removeItem(entries[index].key)
+      }
+    }
+  } catch {
+    // Ignore cleanup errors.
+  }
+}
+
+function listPendingTransfers(senderId?: string): PendingCreditTransferEntry[] {
+  if (typeof window === 'undefined') return []
+
+  cleanupPendingTransfers()
+
+  const results: PendingCreditTransferEntry[] = []
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i)
+    if (!key?.startsWith(PENDING_TRANSFER_PREFIX)) continue
+
+    const raw = localStorage.getItem(key)
+    if (!raw) continue
+
+    try {
+      const parsed = JSON.parse(raw) as PendingCreditTransferEntry
+      if (!senderId || parsed.senderId === senderId) {
+        results.push(parsed)
+      }
+    } catch {
+      localStorage.removeItem(key)
+    }
+  }
+
+  return results
+}
+
+function updatePendingTransfer(entry: PendingCreditTransferEntry): void {
+  savePendingTransfer(entry)
+}
+
+class CreditTransferService {
+  private verificationCache = new Map<string, Promise<CreditTransferReceiptVerification>>()
+
+  private findMatchingTransferKey(
+    privateKeyWif: string,
+    wasmPublicKeys: WasmIdentityPublicKey[],
+    specificKeyId?: number
+  ): WasmIdentityPublicKey | null {
+    const network = (process.env.NEXT_PUBLIC_NETWORK as 'testnet' | 'mainnet') || 'testnet'
+    const activeKeys = wasmPublicKeys.filter((key) => !key.disabledAt)
+    const transferKeys = activeKeys.filter((key) => key.purposeNumber === KeyPurpose.TRANSFER)
+
+    if (transferKeys.length === 0) {
+      return null
+    }
+
+    const keyInfos: IdentityPublicKeyInfo[] = transferKeys.map((key) => {
+      const dataHex = key.data
+      const data = new Uint8Array(dataHex.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || [])
+
+      return {
+        id: key.keyId,
+        type: key.keyTypeNumber,
+        purpose: key.purposeNumber,
+        securityLevel: key.securityLevelNumber,
+        data,
+      }
+    })
+
+    const match = findMatchingKeyIndex(privateKeyWif, keyInfos, network)
+    if (!match) {
+      return null
+    }
+
+    if (specificKeyId !== undefined && match.keyId !== specificKeyId) {
+      return null
+    }
+
+    return transferKeys.find((key) => key.keyId === match.keyId) || null
+  }
+
+  private async deriveReceiptId(transitionBytes: Uint8Array): Promise<string> {
+    const digest = await sha256(transitionBytes)
+    return bs58.encode(digest)
+  }
+
+  private async buildSignedTransfer(options: CreditTransferOptions): Promise<{
+    stateTransition: StateTransition
+    transitionHash: string
+    transitionBytes: Uint8Array
+    receiptId: string
+  }> {
+    const sdk = await getEvoSdk()
+    const identity = await sdk.identities.fetch(options.senderId)
+
+    if (!identity) {
+      throw new Error('Sender identity not found')
+    }
+
+    const transferKey = this.findMatchingTransferKey(
+      options.transferKeyWif.trim(),
+      identity.publicKeys,
+      options.keyId
+    )
+    if (!transferKey) {
+      throw new Error('No matching transfer key found. The provided private key does not match any transfer key on this identity.')
+    }
+
+    const currentNonce = await sdk.identities.nonce(options.senderId)
+    if (currentNonce === null || currentNonce === undefined) {
+      throw new Error('Failed to fetch identity nonce')
+    }
+
+    const transfer = identityCreditTransferTransitionFactory.fromObject({
+      amount: options.amountCredits,
+      senderId: bs58.decode(options.senderId),
+      recipientId: bs58.decode(options.recipientId),
+      nonce: currentNonce + BigInt(1),
+      userFeeIncrease: 0,
+    })
+
+    const stateTransition = transfer.toStateTransition()
+    const privateKey = PrivateKey.fromWIF(options.transferKeyWif.trim())
+    stateTransition.sign(privateKey, transferKey)
+
+    const signedTransfer = IdentityCreditTransfer.fromStateTransition(stateTransition)
+    const transitionBytes = signedTransfer.toBytes()
+    const transitionHash = stateTransition.hash(false)
+    const receiptId = await this.deriveReceiptId(transitionBytes)
+
+    return {
+      stateTransition,
+      transitionHash,
+      transitionBytes,
+      receiptId,
+    }
+  }
+
+  async send(options: CreditTransferOptions): Promise<CreditTransferResult> {
+    if (!creditTransferReceiptService.isConfigured()) {
+      return {
+        success: false,
+        error: 'Payment receipt contract is not configured',
+      }
+    }
+
+    if (options.senderId === options.recipientId) {
+      return { success: false, error: 'Cannot transfer credits to the same identity' }
+    }
+
+    const amountCreditsString = options.amountCredits.toString()
+
+    try {
+      const balance = await identityService.getBalance(options.senderId)
+      if (BigInt(balance.confirmed) < options.amountCredits) {
+        return { success: false, error: 'Insufficient balance' }
+      }
+
+      const {
+        stateTransition,
+        transitionHash,
+        transitionBytes,
+        receiptId,
+      } = await this.buildSignedTransfer(options)
+
+      const pendingEntry: PendingCreditTransferEntry = {
+        receiptId,
+        transitionHash,
+        senderId: options.senderId,
+        recipientId: options.recipientId,
+        amountCredits: amountCreditsString,
+        transitionBytes: bytesToBase64(transitionBytes),
+        referenceType: options.referenceType,
+        referenceId: options.referenceId,
+        cachedAt: Date.now(),
+      }
+      savePendingTransfer(pendingEntry)
+
+      const sdk = await getEvoSdk()
+
+      try {
+        await sdk.stateTransitions.broadcastStateTransition(stateTransition)
+      } catch (error) {
+        if (!isAlreadyExistsError(error)) {
+          throw error
+        }
+      }
+
+      let receiptConfirmed = false
+      let receiptAvailable = false
+      try {
+        const receipt = await creditTransferReceiptService.createReceipt(options.senderId, {
+          receiptId,
+          recipientId: options.recipientId,
+          amountCredits: amountCreditsString,
+          transitionHash,
+          transitionBytes,
+          referenceType: options.referenceType,
+          referenceId: options.referenceId,
+        })
+
+        receiptAvailable = true
+        receiptConfirmed = true
+        updatePendingTransfer({
+          ...pendingEntry,
+          receiptId: receipt.id,
+        })
+      } catch (error) {
+        logger.warn('Receipt document creation failed; pending transfer retained for recovery', error)
+      }
+
+      try {
+        const proofResult = await sdk.stateTransitions.waitForResponse(stateTransition)
+        if (!isVerifiedBalanceTransfer(proofResult)) {
+          return {
+            success: true,
+            transitionHash,
+            receiptId,
+            receiptConfirmed,
+            verificationStatus: 'pending',
+          }
+        }
+
+        if (receiptAvailable) {
+          clearPendingTransfer(transitionHash)
+        }
+        identityService.clearCache(options.senderId)
+
+        return {
+          success: true,
+          transitionHash,
+          receiptId,
+          receiptConfirmed,
+          verificationStatus: 'verified',
+          senderBalance: proofResult.sender.balance ?? undefined,
+          recipientBalance: proofResult.recipient.balance ?? undefined,
+        }
+      } catch (error) {
+        if (isTimeoutError(error) || isAlreadyExistsError(error) || isNonFatalWaitError(error)) {
+          identityService.clearCache(options.senderId)
+          return {
+            success: true,
+            transitionHash,
+            receiptId,
+            receiptConfirmed,
+            verificationStatus: 'pending',
+          }
+        }
+
+        throw error
+      }
+    } catch (error) {
+      logger.error('Credit transfer send failed', error)
+      return {
+        success: false,
+        error: extractErrorMessage(error),
+      }
+    }
+  }
+
+  async recoverPendingTransfers(senderId?: string): Promise<void> {
+    if (!creditTransferReceiptService.isConfigured()) {
+      return
+    }
+
+    const pendingTransfers = listPendingTransfers(senderId)
+    if (pendingTransfers.length === 0) {
+      return
+    }
+
+    const sdk = await getEvoSdk()
+
+    for (const entry of pendingTransfers) {
+      try {
+        const transitionBytes = base64ToBytes(entry.transitionBytes)
+        const transfer = IdentityCreditTransfer.fromBytes(transitionBytes)
+        const stateTransition = transfer.toStateTransition()
+        let receiptAvailable = false
+
+        try {
+          await sdk.stateTransitions.broadcastStateTransition(stateTransition)
+        } catch (error) {
+          if (!isAlreadyExistsError(error)) {
+            throw error
+          }
+        }
+
+        try {
+          await creditTransferReceiptService.createReceipt(entry.senderId, {
+            receiptId: entry.receiptId,
+            recipientId: entry.recipientId,
+            amountCredits: entry.amountCredits,
+            transitionHash: entry.transitionHash,
+            transitionBytes,
+            referenceType: entry.referenceType,
+            referenceId: entry.referenceId,
+          })
+          receiptAvailable = true
+        } catch (error) {
+          logger.warn('Pending receipt publication still failing', error)
+        }
+
+        try {
+          const proofResult = await sdk.stateTransitions.waitForResponse(stateTransition)
+          if (isVerifiedBalanceTransfer(proofResult) && receiptAvailable) {
+            clearPendingTransfer(entry.transitionHash)
+          }
+        } catch (error) {
+          if (!isTimeoutError(error) && !isAlreadyExistsError(error) && !isNonFatalWaitError(error)) {
+            logger.warn('Pending receipt verification failed', error)
+          }
+        }
+      } catch (error) {
+        logger.warn('Failed to recover pending credit transfer', error)
+      }
+    }
+  }
+
+  async verifyReceipt(
+    receiptId: string,
+    options: CreditTransferVerificationOptions = {}
+  ): Promise<CreditTransferReceiptVerification> {
+    const cacheKey = JSON.stringify({ receiptId, ...options })
+    const cached = this.verificationCache.get(cacheKey)
+    if (cached) {
+      return cached
+    }
+
+    const verificationPromise = this.verifyReceiptUncached(receiptId, options)
+      .finally(() => {
+        this.verificationCache.delete(cacheKey)
+      })
+    this.verificationCache.set(cacheKey, verificationPromise)
+    return verificationPromise
+  }
+
+  private async verifyReceiptUncached(
+    receiptId: string,
+    options: CreditTransferVerificationOptions
+  ): Promise<CreditTransferReceiptVerification> {
+    if (!creditTransferReceiptService.isConfigured()) {
+      return {
+        status: 'error',
+        receiptId,
+        error: 'Payment receipt contract is not configured',
+      }
+    }
+
+    try {
+      const receipt = await creditTransferReceiptService.getById(receiptId)
+      if (!receipt) {
+        return {
+          status: 'pending',
+          receiptId,
+          receipt: null,
+        }
+      }
+
+      const transfer = IdentityCreditTransfer.fromBytes(receipt.transitionBytes)
+      const stateTransition = transfer.toStateTransition()
+      const transitionHash = stateTransition.hash(false)
+      const senderId = transfer.senderId.toString()
+      const recipientId = transfer.recipientId.toString()
+      const amountCredits = transfer.amount.toString()
+
+      if (receipt.ownerId !== senderId) {
+        return { status: 'invalid', receiptId, receipt, error: 'Receipt owner does not match transfer sender' }
+      }
+      if (receipt.recipientId !== recipientId) {
+        return { status: 'invalid', receiptId, receipt, error: 'Receipt recipient does not match transfer recipient' }
+      }
+      if (receipt.amountCredits !== amountCredits) {
+        return { status: 'invalid', receiptId, receipt, error: 'Receipt amount does not match transfer amount' }
+      }
+      if (receipt.transitionHash !== transitionHash) {
+        return { status: 'invalid', receiptId, receipt, error: 'Receipt hash does not match signed transition hash' }
+      }
+      if (options.expectedSenderId && options.expectedSenderId !== senderId) {
+        return { status: 'invalid', receiptId, receipt, error: 'Unexpected transfer sender' }
+      }
+      if (options.expectedRecipientId && options.expectedRecipientId !== recipientId) {
+        return { status: 'invalid', receiptId, receipt, error: 'Unexpected transfer recipient' }
+      }
+      if (options.expectedAmountCredits && options.expectedAmountCredits !== amountCredits) {
+        return { status: 'invalid', receiptId, receipt, error: 'Unexpected transfer amount' }
+      }
+      if (options.expectedReferenceType && receipt.referenceType !== options.expectedReferenceType) {
+        return { status: 'invalid', receiptId, receipt, error: 'Unexpected receipt reference type' }
+      }
+      if (options.expectedReferenceId && receipt.referenceId !== options.expectedReferenceId) {
+        return { status: 'invalid', receiptId, receipt, error: 'Unexpected receipt reference ID' }
+      }
+
+      try {
+        const sdk = await getEvoSdk()
+        const proofResult = await sdk.stateTransitions.waitForResponse(stateTransition)
+        if (!isVerifiedBalanceTransfer(proofResult)) {
+          return {
+            status: 'pending',
+            receiptId,
+            receipt,
+            amountCredits,
+            senderId,
+            recipientId,
+            transitionHash,
+          }
+        }
+
+        const provedSenderId = proofResult.sender.id.toString()
+        const provedRecipientId = proofResult.recipient.id.toString()
+        if (provedSenderId !== senderId || provedRecipientId !== recipientId) {
+          return { status: 'invalid', receiptId, receipt, error: 'Verified proof identities do not match the signed transfer' }
+        }
+
+        return {
+          status: 'verified',
+          receiptId,
+          receipt,
+          amountCredits,
+          senderId,
+          recipientId,
+          transitionHash,
+        }
+      } catch (error) {
+        if (isTimeoutError(error) || isAlreadyExistsError(error) || isNonFatalWaitError(error)) {
+          return {
+            status: 'pending',
+            receiptId,
+            receipt,
+            amountCredits,
+            senderId,
+            recipientId,
+            transitionHash,
+          }
+        }
+
+        return {
+          status: 'error',
+          receiptId,
+          receipt,
+          amountCredits,
+          senderId,
+          recipientId,
+          transitionHash,
+          error: extractErrorMessage(error),
+        }
+      }
+    } catch (error) {
+      return {
+        status: 'error',
+        receiptId,
+        error: extractErrorMessage(error),
+      }
+    }
+  }
+}
+
+export const creditTransferService = new CreditTransferService()

--- a/lib/services/credit-transfer-service.ts
+++ b/lib/services/credit-transfer-service.ts
@@ -385,7 +385,7 @@ class CreditTransferService {
         const receipt = await creditTransferReceiptService.createReceipt(options.senderId, {
           receiptId,
           recipientId: options.recipientId,
-          amountCredits: amountCreditsString,
+          amountCredits: options.amountCredits,
           transitionHash,
           transitionBytes,
           referenceType: options.referenceType,
@@ -482,7 +482,7 @@ class CreditTransferService {
           await creditTransferReceiptService.createReceipt(entry.senderId, {
             receiptId: entry.receiptId,
             recipientId: entry.recipientId,
-            amountCredits: entry.amountCredits,
+            amountCredits: BigInt(entry.amountCredits),
             transitionHash: entry.transitionHash,
             transitionBytes,
             referenceType: entry.referenceType,
@@ -554,7 +554,7 @@ class CreditTransferService {
       const transitionHash = stateTransition.hash(false)
       const senderId = transfer.senderId.toString()
       const recipientId = transfer.recipientId.toString()
-      const amountCredits = transfer.amount.toString()
+      const amountCredits = transfer.amount
 
       if (receipt.ownerId !== senderId) {
         return { status: 'invalid', receiptId, receipt, error: 'Receipt owner does not match transfer sender' }
@@ -574,7 +574,7 @@ class CreditTransferService {
       if (options.expectedRecipientId && options.expectedRecipientId !== recipientId) {
         return { status: 'invalid', receiptId, receipt, error: 'Unexpected transfer recipient' }
       }
-      if (options.expectedAmountCredits && options.expectedAmountCredits !== amountCredits) {
+      if (options.expectedAmountCredits && BigInt(options.expectedAmountCredits) !== amountCredits) {
         return { status: 'invalid', receiptId, receipt, error: 'Unexpected transfer amount' }
       }
       if (options.expectedReferenceType && receipt.referenceType !== options.expectedReferenceType) {

--- a/lib/services/evo-sdk-service.ts
+++ b/lib/services/evo-sdk-service.ts
@@ -1,6 +1,6 @@
 import { logger } from '@/lib/logger';
 import { EvoSDK } from '@dashevo/evo-sdk';
-import { DPNS_CONTRACT_ID, YAPPR_DM_CONTRACT_ID, YAPPR_PROFILE_CONTRACT_ID, KEY_EXCHANGE_CONTRACT_ID, YAPPR_BLOG_CONTRACT_ID, YAPPR_STOREFRONT_CONTRACT_ID, YAPPR_VAULT_CONTRACT_ID, YAPPR_AUTH_VAULT_CONTRACT_ID } from '../constants';
+import { DPNS_CONTRACT_ID, YAPPR_DM_CONTRACT_ID, YAPPR_PROFILE_CONTRACT_ID, KEY_EXCHANGE_CONTRACT_ID, YAPPR_BLOG_CONTRACT_ID, YAPPR_STOREFRONT_CONTRACT_ID, YAPPR_VAULT_CONTRACT_ID, YAPPR_AUTH_VAULT_CONTRACT_ID, YAPPR_PAYMENT_RECEIPT_CONTRACT_ID } from '../constants';
 
 export interface EvoSdkConfig {
   network: 'testnet' | 'mainnet';
@@ -137,6 +137,9 @@ class EvoSdkService {
     }
     if (YAPPR_AUTH_VAULT_CONTRACT_ID && !YAPPR_AUTH_VAULT_CONTRACT_ID.includes('PLACEHOLDER')) {
       contractsToFetch.push({ id: YAPPR_AUTH_VAULT_CONTRACT_ID, name: 'AuthVault' });
+    }
+    if (YAPPR_PAYMENT_RECEIPT_CONTRACT_ID && !YAPPR_PAYMENT_RECEIPT_CONTRACT_ID.includes('PLACEHOLDER')) {
+      contractsToFetch.push({ id: YAPPR_PAYMENT_RECEIPT_CONTRACT_ID, name: 'PaymentReceipt' });
     }
 
     // Fetch all contracts in parallel

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -16,6 +16,8 @@ export { directMessageService } from './direct-message-service';
 export { hashtagService } from './hashtag-service';
 export { notificationService } from './notification-service';
 export { tipService, CREDITS_PER_DASH, MIN_TIP_CREDITS } from './tip-service';
+export { creditTransferService } from './credit-transfer-service';
+export { creditTransferReceiptService } from './credit-transfer-receipt-service';
 export { blogService } from './blog-service';
 export { blogPostService } from './blog-post-service';
 export { blogCommentService } from './blog-comment-service';
@@ -50,6 +52,11 @@ export type {
 export type { ParsedPaymentUri, SocialLink } from '../../types';
 export type { PostHashtagDocument, TrendingHashtag } from './hashtag-service';
 export type { TipResult } from './tip-service';
+export type {
+  CreditTransferResult,
+  CreditTransferOptions,
+  CreditTransferVerificationOptions,
+} from './credit-transfer-service';
 export type { NotificationResult } from './notification-service';
 export type { CreateBlogData, UpdateBlogData } from './blog-service';
 export type { CreateBlogPostData, UpdateBlogPostData, BlogPostQueryOptions } from './blog-post-service';

--- a/lib/services/store-order-service.ts
+++ b/lib/services/store-order-service.ts
@@ -158,6 +158,7 @@ class StoreOrderService extends BaseDocumentService<StoreOrder> {
       shippingCost,
       total: subtotal + shippingCost,
       currency,
+      paymentMethod: 'externalUri',
       paymentUri,
       notes,
       refundAddress

--- a/lib/services/tip-service.ts
+++ b/lib/services/tip-service.ts
@@ -1,29 +1,21 @@
 import { logger } from '@/lib/logger';
-import { getEvoSdk } from './evo-sdk-service';
 import { identityService } from './identity-service';
-import { signerService, KeyPurpose } from './signer-service';
-import { wallet } from '@dashevo/evo-sdk';
+import { creditTransferService } from './credit-transfer-service';
 import { TipInfo } from '../../types';
-import { findMatchingKeyIndex, type IdentityPublicKeyInfo } from '@/lib/crypto/keys';
-import type { IdentityPublicKey as WasmIdentityPublicKey } from '@dashevo/wasm-sdk/compressed';
 
 export interface TipResult {
-  success: boolean;
-  transactionHash?: string;
-  error?: string;
-  errorCode?: 'INSUFFICIENT_BALANCE' | 'SELF_TIP' | 'NETWORK_ERROR' | 'INVALID_AMOUNT' | 'INVALID_KEY';
+  success: boolean
+  transactionHash?: string
+  receiptId?: string
+  verificationStatus?: 'verified' | 'pending'
+  error?: string
+  errorCode?: 'INSUFFICIENT_BALANCE' | 'SELF_TIP' | 'NETWORK_ERROR' | 'INVALID_AMOUNT' | 'INVALID_KEY'
 }
 
-// Regex to parse tip content: tip:AMOUNT_CREDITS followed by optional message
-// Format: tip:CREDITS\nmessage (message is optional)
-// Using [\s\S]* instead of .* with 's' flag for cross-line matching
-//
-// TODO: Once the Dash Platform SDK exposes transition IDs from creditTransfer(),
-// update format to: tip:CREDITS@TRANSITION_ID\nmessage
-// This will allow on-chain verification of tip amounts.
-// See: wasm-sdk/src/state_transitions/identity/mod.rs - identity_credit_transfer
-// currently returns { status, senderId, recipientId, amount, message } but no hash.
-const TIP_CONTENT_REGEX = /^tip:(\d+)(?:\n([\s\S]*))?$/;
+// Legacy format: tip:CREDITS\nmessage
+const LEGACY_TIP_CONTENT_REGEX = /^tip:(\d+)(?:\n([\s\S]*))?$/
+// Verified format: tip:CREDITS@RECEIPT_ID\nmessage
+const RECEIPT_TIP_CONTENT_REGEX = /^tip:(\d+)@([^\n]+?)(?:\n([\s\S]*))?$/
 
 // Conversion: 1 DASH = 100,000,000,000 credits on Dash Platform
 // (Platform credits are different from core duffs)
@@ -31,61 +23,6 @@ export const CREDITS_PER_DASH = 100_000_000_000;
 export const MIN_TIP_CREDITS = 100_000_000; // 0.001 DASH minimum
 
 class TipService {
-  /**
-   * Find the transfer key that matches the provided private key
-   *
-   * This verifies that the private key corresponds to one of the identity's
-   * transfer keys, preventing signer/key mismatches.
-   *
-   * @param privateKeyWif - The private key in WIF format
-   * @param wasmPublicKeys - The identity's WASM public keys
-   * @param specificKeyId - Optional specific key ID to use
-   * @returns The matching transfer key or null if not found
-   */
-  private findMatchingTransferKey(
-    privateKeyWif: string,
-    wasmPublicKeys: WasmIdentityPublicKey[],
-    specificKeyId?: number
-  ): WasmIdentityPublicKey | null {
-    const network = (process.env.NEXT_PUBLIC_NETWORK as 'testnet' | 'mainnet') || 'testnet';
-    const activeKeys = wasmPublicKeys.filter(k => !k.disabledAt);
-    const transferKeys = activeKeys.filter(k => k.purposeNumber === KeyPurpose.TRANSFER);
-
-    if (transferKeys.length === 0) {
-      return null;
-    }
-
-    // Convert transfer keys to format for matching
-    const keyInfos: IdentityPublicKeyInfo[] = transferKeys.map(key => {
-      const dataHex = key.data;
-      const data = new Uint8Array(dataHex.match(/.{1,2}/g)?.map(byte => parseInt(byte, 16)) || []);
-      return {
-        id: key.keyId,
-        type: key.keyTypeNumber,
-        purpose: key.purposeNumber,
-        securityLevel: key.securityLevelNumber,
-        data
-      };
-    });
-
-    // Find which transfer key matches the provided private key
-    const match = findMatchingKeyIndex(privateKeyWif, keyInfos, network);
-
-    if (!match) {
-      logger.error('Transfer private key does not match any transfer key on this identity');
-      return null;
-    }
-
-    // If a specific key ID was requested, verify it matches
-    if (specificKeyId !== undefined && match.keyId !== specificKeyId) {
-      logger.error(`Requested key ID ${specificKeyId} but private key matches key ID ${match.keyId}`);
-      return null;
-    }
-
-    logger.info(`Matched transfer key: id=${match.keyId}`);
-    return transferKeys.find(k => k.keyId === match.keyId) || null;
-  }
-
   /**
    * Send a tip (credit transfer) to another user and optionally create a tip post
    * @param senderId - The sender's identity ID
@@ -135,125 +72,49 @@ class TipService {
         };
       }
 
-      const sdk = await getEvoSdk();
-
-      // Log transfer details for debugging
-      logger.info('=== Credit Transfer Debug ===');
-      logger.info(`Sender ID: ${senderId}`);
-      logger.info(`Recipient ID: ${recipientId}`);
-      logger.info(`Amount: ${amountCredits} credits`);
-      logger.info(`Key ID: ${keyId !== undefined ? keyId : 'auto-detect'}`);
-      logger.info(`Private key length: ${transferKeyWif.trim().length}`);
-      logger.info(`Private key starts with: ${transferKeyWif.trim().substring(0, 4)}...`);
-
-      // Fetch sender identity to see available keys
-      try {
-        const identity = await sdk.identities.fetch(senderId);
-        if (identity) {
-          const identityJson = identity.toJSON();
-          logger.info('Sender identity public keys:', JSON.stringify(identityJson.publicKeys, null, 2));
-
-          // Try to derive public key from the provided private key and compare
-          try {
-            const keyPair = await wallet.keyPairFromWif(transferKeyWif.trim());
-            logger.info('Derived key pair from WIF:', keyPair);
-
-            // Find transfer keys (purpose 3) on the identity
-            interface IdentityPublicKey { id: number; purpose: number; data?: string }
-            const transferKeys = identityJson.publicKeys.filter((k: IdentityPublicKey) => k.purpose === 3);
-            logger.info('Transfer keys on identity:', transferKeys);
-
-            if (keyPair?.publicKey) {
-              // public_key is a hex string, convert to base64 for comparison
-              const hexToBytes = (hex: string) => {
-                const bytes = [];
-                for (let i = 0; i < hex.length; i += 2) {
-                  bytes.push(parseInt(hex.substr(i, 2), 16));
-                }
-                return bytes;
-              };
-              const pubKeyBytes = hexToBytes(keyPair.publicKey);
-              const pubKeyBase64 = btoa(String.fromCharCode.apply(null, pubKeyBytes));
-              logger.info('Derived public key (hex):', keyPair.publicKey);
-              logger.info('Derived public key (base64):', pubKeyBase64);
-
-              // Compare with key 3's public key
-              const key3 = identityJson.publicKeys.find((k: IdentityPublicKey) => k.id === 3);
-              if (key3) {
-                logger.info('Key 3 public key (from identity):', key3.data);
-                logger.info('Keys match:', pubKeyBase64 === key3.data);
-              }
-            }
-          } catch (keyError) {
-            logger.info('Error deriving key pair:', keyError);
-          }
-        }
-      } catch (e) {
-        logger.info('Could not fetch identity for debugging:', e);
-      }
-
-      // Fetch sender identity WASM object
-      const identity = await sdk.identities.fetch(senderId);
-      if (!identity) {
-        return {
-          success: false,
-          error: 'Sender identity not found',
-          errorCode: 'NETWORK_ERROR'
-        };
-      }
-
-      // Get WASM public keys and find the transfer key that matches the private key
-      const wasmPublicKeys = identity.publicKeys;
-      const transferKey = this.findMatchingTransferKey(transferKeyWif.trim(), wasmPublicKeys, keyId);
-      if (!transferKey) {
-        return {
-          success: false,
-          error: 'No matching transfer key found. The provided private key does not match any transfer key on this identity.',
-          errorCode: 'INVALID_KEY'
-        };
-      }
-
-      // Log transfer details
-      logger.info('Transfer args:', JSON.stringify({
+      const result = await creditTransferService.send({
         senderId,
         recipientId,
-        amount: amountCredits.toString(),
-        keyId: transferKey.keyId
-      }, null, 2));
+        amountCredits: BigInt(amountCredits),
+        transferKeyWif,
+        keyId,
+        referenceType: postId ? 'tip' : undefined,
+        referenceId: postId || undefined,
+      })
 
-      // Create signer with the transfer key
-      const { signer, identityKey: signingKey } = await signerService.createSignerFromWasmKey(
-        transferKeyWif.trim(),
-        transferKey
-      );
+      if (!result.success) {
+        const lowerError = (result.error || '').toLowerCase()
+        if (
+          lowerError.includes('private') ||
+          lowerError.includes('key') ||
+          lowerError.includes('signature') ||
+          lowerError.includes('wif') ||
+          lowerError.includes('mismatch')
+        ) {
+          return {
+            success: false,
+            error: 'Invalid transfer key. The key you provided does not match this identity.',
+            errorCode: 'INVALID_KEY',
+          }
+        }
 
-      logger.info('Calling sdk.identities.creditTransfer...');
-      // Cast needed: SDK has duplicate IdentityCreditTransferOptions interfaces that get merged.
-      // The high-level facade only needs { identity, recipientId, amount, signer, signingKey? }.
-      const result = await sdk.identities.creditTransfer({
-        identity,
-        recipientId,
-        amount: BigInt(amountCredits),
-        signer,
-        signingKey
-      } as Parameters<typeof sdk.identities.creditTransfer>[0]);
+        return {
+          success: false,
+          error: result.error || 'Transfer failed',
+          errorCode: 'NETWORK_ERROR',
+        }
+      }
 
-      // Clear sender's balance cache so it refreshes
-      identityService.clearCache(senderId);
-
-      logger.info('Tip transfer result:', result);
-
-      // Create tip post as a reply to the tipped post (only if postId provided)
-      // TODO: Once SDK returns transition ID, pass it for on-chain verification
-      if (postId) {
-        await this.createTipPost(senderId, postId, recipientId, amountCredits, message);
+      if (postId && result.receiptId) {
+        await this.createTipPost(senderId, postId, recipientId, amountCredits, result.receiptId, message)
       }
 
       return {
         success: true,
-        // TODO: Return actual transaction hash once SDK exposes it
-        transactionHash: 'confirmed'
-      };
+        transactionHash: result.transitionHash,
+        receiptId: result.receiptId,
+        verificationStatus: result.verificationStatus,
+      }
 
     } catch (error) {
       logger.error('Tip transfer error:', error);
@@ -262,23 +123,6 @@ class TipService {
         ((error as { message?: string })?.message) ||
         (typeof error === 'string' ? error : 'Unknown error');
 
-      // Handle known DAPI timeout issue (like in state-transition-service)
-      if (errorMessage.includes('504') || errorMessage.includes('timeout') || errorMessage.includes('wait_for_state_transition_result')) {
-        // Assume success - clear cache and return optimistic result
-        identityService.clearCache(senderId);
-
-        // Create tip post (amount is known even if confirmation timed out)
-        if (postId) {
-          await this.createTipPost(senderId, postId, recipientId, amountCredits, message);
-        }
-
-        return {
-          success: true,
-          transactionHash: 'pending-confirmation'
-        };
-      }
-
-      // Check for invalid key errors - match various SDK error patterns
       const lowerError = errorMessage.toLowerCase();
       if (
         lowerError.includes('private') ||
@@ -295,14 +139,14 @@ class TipService {
           success: false,
           error: 'Invalid transfer key. The key you provided does not match this identity.',
           errorCode: 'INVALID_KEY'
-        };
+        }
       }
 
       return {
         success: false,
         error: `Transfer failed: ${errorMessage}`,
         errorCode: 'NETWORK_ERROR'
-      };
+      }
     }
   }
 
@@ -317,14 +161,14 @@ class TipService {
     postId: string,
     postOwnerId: string,
     amountCredits: number,
+    receiptId: string,
     tipMessage?: string
   ): Promise<void> {
     try {
-      // Format: tip:CREDITS\nmessage (message is optional)
-      // Amount is self-reported until SDK provides transition ID for verification
+      // Format: tip:CREDITS@RECEIPT_ID\nmessage
       const content = tipMessage
-        ? `tip:${amountCredits}\n${tipMessage}`
-        : `tip:${amountCredits}`;
+        ? `tip:${amountCredits}@${receiptId}\n${tipMessage}`
+        : `tip:${amountCredits}@${receiptId}`;
 
       // Tips are created as replies to the tipped post
       const { replyService } = await import('./reply-service');
@@ -372,24 +216,36 @@ class TipService {
    * Parse tip content from post content
    * Returns TipInfo if the content is a tip post, null otherwise
    *
-   * Current format: tip:CREDITS\nmessage
-   * TODO: Future format with verification: tip:CREDITS@TRANSITION_ID\nmessage
+   * Supported formats:
+   * - legacy: tip:CREDITS\nmessage
+   * - receipt-backed: tip:CREDITS@RECEIPT_ID\nmessage
    */
   parseTipContent(content: string): TipInfo | null {
-    const match = content.match(TIP_CONTENT_REGEX);
-    if (!match) return null;
+    const receiptMatch = content.match(RECEIPT_TIP_CONTENT_REGEX)
+    if (receiptMatch) {
+      return {
+        amount: parseInt(receiptMatch[1], 10),
+        receiptId: receiptMatch[2].trim(),
+        message: (receiptMatch[3] || '').trim(),
+        verificationStatus: 'pending',
+      }
+    }
+
+    const legacyMatch = content.match(LEGACY_TIP_CONTENT_REGEX)
+    if (!legacyMatch) return null
 
     return {
-      amount: parseInt(match[1], 10),
-      message: (match[2] || '').trim()
-    };
+      amount: parseInt(legacyMatch[1], 10),
+      message: (legacyMatch[2] || '').trim(),
+      verificationStatus: 'legacy',
+    }
   }
 
   /**
    * Check if post content is a tip
    */
   isTipPost(content: string): boolean {
-    return TIP_CONTENT_REGEX.test(content);
+    return RECEIPT_TIP_CONTENT_REGEX.test(content) || LEGACY_TIP_CONTENT_REGEX.test(content)
   }
 
   /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,7 @@
 export * from '../types/user'
 export * from '../types/post'
 export * from '../types/store'
+export * from '../types/payment'
 export * from '../types/notification'
 
 import type { BlogThemeConfig } from '@/lib/blog/theme-types'

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -5,7 +5,7 @@ export interface CreditTransferReceiptDocument {
   $ownerId: string
   $createdAt: number
   recipientId: Uint8Array | string
-  amountCredits: string
+  amountCredits: number | string
   transitionHash: Uint8Array | string
   transitionBytes: Uint8Array | string
   referenceType?: string
@@ -17,7 +17,7 @@ export interface CreditTransferReceipt {
   ownerId: string
   createdAt: Date
   recipientId: string
-  amountCredits: string
+  amountCredits: bigint
   transitionHash: string
   transitionBytes: Uint8Array
   referenceType?: string
@@ -30,7 +30,7 @@ export interface CreditTransferReceiptVerification {
   status: CreditTransferReceiptVerificationStatus
   receiptId: string
   receipt?: CreditTransferReceipt | null
-  amountCredits?: string
+  amountCredits?: bigint
   senderId?: string
   recipientId?: string
   transitionHash?: string

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -1,0 +1,38 @@
+export type CreditTransferReceiptReferenceType = string
+
+export interface CreditTransferReceiptDocument {
+  $id: string
+  $ownerId: string
+  $createdAt: number
+  recipientId: Uint8Array | string
+  amountCredits: string
+  transitionHash: string
+  transitionBytes: Uint8Array | string
+  referenceType?: string
+  referenceId?: Uint8Array | string
+}
+
+export interface CreditTransferReceipt {
+  id: string
+  ownerId: string
+  createdAt: Date
+  recipientId: string
+  amountCredits: string
+  transitionHash: string
+  transitionBytes: Uint8Array
+  referenceType?: string
+  referenceId?: string
+}
+
+export type CreditTransferReceiptVerificationStatus = 'verified' | 'pending' | 'invalid' | 'error'
+
+export interface CreditTransferReceiptVerification {
+  status: CreditTransferReceiptVerificationStatus
+  receiptId: string
+  receipt?: CreditTransferReceipt | null
+  amountCredits?: string
+  senderId?: string
+  recipientId?: string
+  transitionHash?: string
+  error?: string
+}

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -6,7 +6,7 @@ export interface CreditTransferReceiptDocument {
   $createdAt: number
   recipientId: Uint8Array | string
   amountCredits: string
-  transitionHash: string
+  transitionHash: Uint8Array | string
   transitionBytes: Uint8Array | string
   referenceType?: string
   referenceId?: Uint8Array | string

--- a/types/post.ts
+++ b/types/post.ts
@@ -7,6 +7,8 @@ import type { User } from './user'
 export interface TipInfo {
   amount: number        // Tip amount in credits (self-reported, unverified)
   message: string       // The tip message (content after the tip: line)
+  receiptId?: string    // Receipt document ID for detached verification
+  verificationStatus?: 'verified' | 'pending' | 'legacy'
   transitionId?: string // Future: will be used for on-chain verification
 }
 

--- a/types/store.ts
+++ b/types/store.ts
@@ -1,5 +1,20 @@
 import type { ParsedPaymentUri, SocialLink } from './user'
 
+export type OrderPaymentMethod = 'externalUri' | 'platformCredits'
+
+export interface ExternalUriPaymentMethod {
+  kind: 'externalUri'
+  paymentUri: ParsedPaymentUri
+}
+
+export interface PlatformCreditsPaymentMethod {
+  kind: 'platformCredits'
+  recipientId: string
+  label?: string
+}
+
+export type StorePaymentMethod = ExternalUriPaymentMethod | PlatformCreditsPaymentMethod
+
 // Store policy for arbitrary seller-defined policies
 export interface StorePolicy {
   name: string     // Policy title, e.g., "Return Policy"
@@ -256,8 +271,11 @@ export interface OrderPayload {
   shippingCost: number
   total: number
   currency: string
-  paymentUri: string
+  paymentMethod?: OrderPaymentMethod
+  paymentUri?: string
   txid?: string
+  creditTransferReceiptId?: string
+  paymentAmountCredits?: string
   notes?: string
   refundAddress?: string
 }


### PR DESCRIPTION
## Summary
- add a shared `creditTransferReceipt` contract and a manual receipt-backed credit transfer service
- update tipping to publish receipt-backed tip replies and verify receipt status in the UI
- prepare storefront order payloads and seller views for future Platform-credit receipt verification
- configure the deployed receipt contract and store receipt hashes/amounts using proper binary and integer contract fields

## Testing
- `npm run lint`
- `npm run build`

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Seller order page now verifies and displays credit transfer receipt status for platform-credit payments
  * Tip posts show live verification status badges (replacing static messaging)
  * Tip modal displays receipt information with copy-to-clipboard functionality after successful tips
  * Platform credit payments tracked with receipt IDs and verification status
  * Pending credit transfers automatically recover on login

<!-- end of auto-generated comment: release notes by coderabbit.ai -->