### PR TITLE
fix: upgrade evo sdk for testnet proofs

### DIFF
--- a/lib/dash-platform-client.ts
+++ b/lib/dash-platform-client.ts
@@ -4,6 +4,7 @@ import { logger } from '@/lib/logger';
 // Import the centralized SDK service
 import { evoSdkService } from './services/evo-sdk-service'
 import { YAPPR_CONTRACT_ID } from './constants'
+import { documentToPlainObject } from './services/sdk-helpers'
 
 export class DashPlatformClient {
   private sdk: any = null
@@ -164,12 +165,11 @@ export class DashPlatformClient {
       if (profileResponse instanceof Map) {
         profiles = Array.from(profileResponse.values())
           .filter(Boolean)
-          .map((doc: unknown) => {
-            const d = doc as { toJSON?: () => unknown }
-            return typeof d.toJSON === 'function' ? d.toJSON() : doc
-          })
+          .map(documentToPlainObject)
       } else if (Array.isArray(profileResponse)) {
         profiles = profileResponse
+          .filter(Boolean)
+          .map(documentToPlainObject)
       }
 
       logger.info('Profiles found:', profiles)
@@ -298,12 +298,11 @@ export class DashPlatformClient {
         if (postsResponse instanceof Map) {
           posts = Array.from(postsResponse.values())
             .filter(Boolean)
-            .map((doc: unknown) => {
-              const d = doc as { toJSON?: () => unknown }
-              return typeof d.toJSON === 'function' ? d.toJSON() : doc
-            })
+            .map(documentToPlainObject)
         } else if (Array.isArray(postsResponse)) {
           posts = postsResponse
+            .filter(Boolean)
+            .map(documentToPlainObject)
         }
 
         logger.info(`DashPlatformClient: Found ${posts.length} posts`)

--- a/lib/services/direct-message-service.ts
+++ b/lib/services/direct-message-service.ts
@@ -6,6 +6,7 @@ import { dpnsService } from './dpns-service'
 import { unifiedProfileService } from './unified-profile-service'
 import {
   bytesToBase64QueryOperand,
+  documentToPlainObject,
   identifierStringToDocumentBytes,
   type DocumentWhereClause,
 } from './sdk-helpers'
@@ -733,20 +734,18 @@ class DirectMessageService {
     if (response instanceof Map) {
       return Array.from(response.values())
         .filter(Boolean)
-        .map((doc: unknown) => {
-          const d = doc as { toJSON?: () => unknown }
-          return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as Record<string, unknown>
-        })
+        .map(documentToPlainObject)
     }
     if (Array.isArray(response)) {
-      return response.map((doc: unknown) => {
-        const d = doc as { toJSON?: () => unknown }
-        return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as Record<string, unknown>
-      })
+      return response
+        .filter(Boolean)
+        .map(documentToPlainObject)
     }
-    const respObj = response as { documents?: Record<string, unknown>[] }
-    if (respObj?.documents) {
+    const respObj = response as { documents?: unknown[] }
+    if (Array.isArray(respObj?.documents)) {
       return respObj.documents
+        .filter(Boolean)
+        .map(documentToPlainObject)
     }
     return []
   }

--- a/lib/services/document-builder-service.ts
+++ b/lib/services/document-builder-service.ts
@@ -13,6 +13,7 @@
  * the WASM module is initialized before creating any Document objects.
  */
 import { getEvoSdk } from './evo-sdk-service';
+import { documentToPlainObject } from './sdk-helpers';
 import { Document } from '@dashevo/evo-sdk';
 import bs58 from 'bs58';
 
@@ -159,9 +160,9 @@ class DocumentBuilderService {
    * @returns Normalized document data with $ prefixed fields
    */
   normalizeDocumentResponse(document: Document | Record<string, unknown>): Record<string, unknown> {
-    // Check if it's a WASM Document with toJSON method
-    if (document && typeof (document as Document).toJSON === 'function') {
-      return (document as Document).toJSON();
+    // Check if it's a WASM Document and extract its JSON-like normalized form.
+    if (document && typeof (document as Document).toObject === 'function') {
+      return documentToPlainObject(document);
     }
 
     // Handle raw objects - normalize field names
@@ -202,9 +203,15 @@ class DocumentBuilderService {
     if (id && typeof (id as { toString?: () => string }).toString === 'function') {
       return (id as { toString: () => string }).toString();
     }
-    // Fallback: try to get from JSON
-    const json = document.toJSON();
-    if (json.$id) return json.$id;
+    // Fallback: convert via toObject() and extract the id field
+    const obj = document.toObject() as { $id?: unknown };
+    if (obj.$id) {
+      const rawId = obj.$id;
+      if (typeof rawId === 'string') return rawId;
+      if (rawId && typeof (rawId as { toString?: () => string }).toString === 'function') {
+        return (rawId as { toString: () => string }).toString();
+      }
+    }
     throw new Error('Unable to extract document ID from Document object');
   }
 }

--- a/lib/services/document-builder-service.ts
+++ b/lib/services/document-builder-service.ts
@@ -13,7 +13,7 @@
  * the WASM module is initialized before creating any Document objects.
  */
 import { getEvoSdk } from './evo-sdk-service';
-import { documentToPlainObject } from './sdk-helpers';
+import { documentToPlainObject, identifierToBase58 } from './sdk-helpers';
 import { Document } from '@dashevo/evo-sdk';
 import bs58 from 'bs58';
 
@@ -208,9 +208,8 @@ class DocumentBuilderService {
     if (obj.$id) {
       const rawId = obj.$id;
       if (typeof rawId === 'string') return rawId;
-      if (rawId && typeof (rawId as { toString?: () => string }).toString === 'function') {
-        return (rawId as { toString: () => string }).toString();
-      }
+      const base58 = identifierToBase58(rawId);
+      if (base58) return base58;
     }
     throw new Error('Unable to extract document ID from Document object');
   }

--- a/lib/services/document-service.ts
+++ b/lib/services/document-service.ts
@@ -2,7 +2,7 @@ import { logger } from '@/lib/logger';
 import { getEvoSdk } from './evo-sdk-service';
 import { stateTransitionService } from './state-transition-service';
 import { YAPPR_CONTRACT_ID } from '../constants';
-import { queryDocuments, type QueryDocumentsOptions, type DocumentWhereClause, type DocumentOrderByClause } from './sdk-helpers';
+import { documentToPlainObject, queryDocuments, type QueryDocumentsOptions, type DocumentWhereClause, type DocumentOrderByClause } from './sdk-helpers';
 
 export interface QueryOptions {
   where?: DocumentWhereClause[];
@@ -149,8 +149,8 @@ export abstract class BaseDocumentService<T> {
         return null;
       }
 
-      // Document has toJSON method — cast to Record for transformDocument
-      const docData = (typeof response.toJSON === 'function' ? response.toJSON() : response) as Record<string, unknown>;
+      // Normalize zero-arg toObject() output back to the JSON-like shape Yappr expects.
+      const docData = documentToPlainObject(response);
       const transformed = this.transformDocument(docData);
 
       // Cache the result

--- a/lib/services/dpns-service.ts
+++ b/lib/services/dpns-service.ts
@@ -2,7 +2,7 @@ import { logger } from '@/lib/logger';
 import { getEvoSdk } from './evo-sdk-service';
 import { SecurityLevel, KeyPurpose, signerService } from './signer-service';
 import { DPNS_CONTRACT_ID, DPNS_DOCUMENT_TYPE } from '../constants';
-import { identifierToBase58 } from './sdk-helpers';
+import { documentToPlainObject, identifierToBase58 } from './sdk-helpers';
 import { findMatchingKeyIndex, getSecurityLevelName, type IdentityPublicKeyInfo } from '@/lib/crypto/keys';
 import type { UsernameCheckResult, UsernameRegistrationResult } from '../types';
 import type { IdentityPublicKey as WasmIdentityPublicKey } from '@dashevo/wasm-sdk/compressed';
@@ -14,25 +14,23 @@ function extractDocuments(response: unknown): Record<string, unknown>[] {
   if (response instanceof Map) {
     return Array.from(response.values())
       .filter(Boolean)
-      .map((doc: unknown) => {
-        const d = doc as { toJSON?: () => unknown };
-        return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as Record<string, unknown>;
-      });
+      .map(documentToPlainObject);
   }
   if (Array.isArray(response)) {
-    return response.map((doc: unknown) => {
-      const d = doc as { toJSON?: () => unknown };
-      return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as Record<string, unknown>;
-    });
+    return response.map(documentToPlainObject);
+  }
+  const maybeDocument = response as { toObject?: () => unknown };
+  if (typeof maybeDocument.toObject === 'function') {
+    return [documentToPlainObject(response)];
   }
   const respObj = response as { documents?: unknown[]; toJSON?: () => unknown };
   if (respObj?.documents) {
-    return respObj.documents as Record<string, unknown>[];
+    return respObj.documents.map(documentToPlainObject);
   }
   if (respObj?.toJSON) {
     const json = respObj.toJSON() as { documents?: unknown[] } | unknown[];
-    if (Array.isArray(json)) return json as Record<string, unknown>[];
-    return (json as { documents?: unknown[] }).documents as Record<string, unknown>[] || [];
+    if (Array.isArray(json)) return json.map(documentToPlainObject);
+    return ((json as { documents?: unknown[] }).documents || []).map(documentToPlainObject);
   }
   return [];
 }

--- a/lib/services/identity-service.ts
+++ b/lib/services/identity-service.ts
@@ -26,6 +26,74 @@ export interface IdentityBalance {
   total: number;
 }
 
+type IdentityPublicKeyLike = {
+  purpose?: unknown;
+  purposeNumber?: unknown;
+  keyType?: unknown;
+  keyTypeNumber?: unknown;
+  type?: unknown;
+};
+
+const IDENTITY_KEY_PURPOSE = {
+  ENCRYPTION: 1,
+  TRANSFER: 3,
+} as const;
+
+const IDENTITY_KEY_TYPE = {
+  ECDSA_SECP256K1: 0,
+} as const;
+
+function normalizeIdentityKeyEnum(value: unknown, names: Record<string, number>): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'bigint') {
+    const asNumber = Number(value);
+    return Number.isSafeInteger(asNumber) ? asNumber : null;
+  }
+
+  if (typeof value === 'string') {
+    const numeric = Number(value);
+    if (Number.isInteger(numeric)) {
+      return numeric;
+    }
+
+    return names[value.toLowerCase()] ?? null;
+  }
+
+  return null;
+}
+
+function getIdentityKeyPurpose(key: IdentityPublicKeyLike): number | null {
+  return normalizeIdentityKeyEnum(key.purposeNumber ?? key.purpose, {
+    authentication: 0,
+    encryption: IDENTITY_KEY_PURPOSE.ENCRYPTION,
+    decryption: 2,
+    transfer: IDENTITY_KEY_PURPOSE.TRANSFER,
+    system: 4,
+    voting: 5,
+  });
+}
+
+function getIdentityKeyType(key: IdentityPublicKeyLike): number | null {
+  return normalizeIdentityKeyEnum(key.keyTypeNumber ?? key.keyType ?? key.type, {
+    ecdsa_secp256k1: IDENTITY_KEY_TYPE.ECDSA_SECP256K1,
+    ecdsa: IDENTITY_KEY_TYPE.ECDSA_SECP256K1,
+    bls12_381: 1,
+    ecdsa_hash160: 2,
+    bip13_script_hash: 3,
+    eddsa_25519_hash160: 4,
+  });
+}
+
+function isIdentityKeyForPurpose(key: IdentityPublicKeyLike, purpose: number): boolean {
+  return (
+    getIdentityKeyPurpose(key) === purpose &&
+    getIdentityKeyType(key) === IDENTITY_KEY_TYPE.ECDSA_SECP256K1
+  );
+}
+
 function safeStringify(value: unknown): string {
   const seen = new WeakSet<object>();
 
@@ -106,9 +174,9 @@ class IdentityService {
 
       const identityInfo: IdentityInfo = {
         id: identity.id || identityId,
-        balance: identity.balance || 0,
+        balance: Number(identity.balance ?? 0),
         publicKeys: normalizedPublicKeys,
-        revision: identity.revision || 0
+        revision: Number(identity.revision ?? 0)
       };
 
       // Cache the result
@@ -349,7 +417,7 @@ class IdentityService {
 
       // Check if encryption key already exists
       const existingKey = identity.publicKeys.find(
-        (key) => key.purpose === 'ENCRYPTION' && key.keyType === 'ECDSA_SECP256K1'
+        (key) => isIdentityKeyForPurpose(key, IDENTITY_KEY_PURPOSE.ENCRYPTION)
       );
       if (existingKey) {
         return { success: false, error: 'Identity already has an encryption key' };
@@ -369,12 +437,14 @@ class IdentityService {
       logger.info(`Creating IdentityPublicKeyInCreation: id=${newKeyId}, purpose=ENCRYPTION, securityLevel=MEDIUM, keyType=ECDSA_SECP256K1`);
       logger.info(`Public key bytes length: ${publicKeyBytes.length}`);
 
-      // v3.1: IdentityPublicKeyInCreation takes an options object
+      // v3.1: IdentityPublicKeyInCreation takes an options object.
+      // dev.8 narrowed PurposeLike/SecurityLevelLike/KeyTypeLike to require
+      // lowercase string variants (or numeric enum values).
       const newKey = new IdentityPublicKeyInCreation({
         keyId: newKeyId,
-        purpose: 'ENCRYPTION',
-        securityLevel: 'MEDIUM',
-        keyType: 'ECDSA_SECP256K1',
+        purpose: 'encryption',
+        securityLevel: 'medium',
+        keyType: 'ecdsa_secp256k1',
         isReadOnly: false,
         data: publicKeyBytes,
       });
@@ -494,9 +564,9 @@ class IdentityService {
         return { success: false, error: 'Identity not found' };
       }
 
-      // Check if transfer key already exists (purpose='TRANSFER')
+      // Check if transfer key already exists (purpose=3)
       const existingKey = identity.publicKeys.find(
-        (key) => key.purpose === 'TRANSFER' && key.keyType === 'ECDSA_SECP256K1'
+        (key) => isIdentityKeyForPurpose(key, IDENTITY_KEY_PURPOSE.TRANSFER)
       );
       if (existingKey) {
         return { success: false, error: 'Identity already has a transfer key' };
@@ -516,12 +586,14 @@ class IdentityService {
       logger.info(`Creating IdentityPublicKeyInCreation: id=${newKeyId}, purpose=TRANSFER, securityLevel=HIGH, keyType=ECDSA_SECP256K1`);
       logger.info(`Public key bytes length: ${publicKeyBytes.length}`);
 
-      // v3.1: IdentityPublicKeyInCreation takes an options object
+      // v3.1: IdentityPublicKeyInCreation takes an options object.
+      // dev.8 narrowed PurposeLike/SecurityLevelLike/KeyTypeLike to require
+      // lowercase string variants (or numeric enum values).
       const newKey = new IdentityPublicKeyInCreation({
         keyId: newKeyId,
-        purpose: 'TRANSFER',
-        securityLevel: 'HIGH',
-        keyType: 'ECDSA_SECP256K1',
+        purpose: 'transfer',
+        securityLevel: 'high',
+        keyType: 'ecdsa_secp256k1',
         isReadOnly: false,
         data: publicKeyBytes,
       });

--- a/lib/services/identity-update-builder.ts
+++ b/lib/services/identity-update-builder.ts
@@ -58,6 +58,34 @@ export interface UnsignedTransitionResult {
 const COMPACT_SIG_BASE = 27
 const COMPACT_SIG_COMPRESSED_FLAG = 4
 
+type RegisteredIdentityKey = {
+  purpose?: string | number
+  purposeNumber?: number
+  keyType?: string | number
+  keyTypeNumber?: number
+  type?: number
+  data?: string
+  toJSON: () => { data: string | Uint8Array }
+}
+
+function keyEnumMatches(value: unknown, numberValue: unknown, expectedNumber: number, expectedName: string): boolean {
+  if (numberValue === expectedNumber || value === expectedNumber) return true
+  return typeof value === 'string' && value.toLowerCase() === expectedName
+}
+
+function keyMatchesPurposeAndType(
+  key: RegisteredIdentityKey,
+  expectedPurposeNumber: number,
+  expectedPurposeName: string,
+  expectedTypeNumber: number,
+  expectedTypeName: string
+): boolean {
+  return (
+    keyEnumMatches(key.purpose, key.purposeNumber, expectedPurposeNumber, expectedPurposeName) &&
+    keyEnumMatches(key.keyType ?? key.type, key.keyTypeNumber ?? key.type, expectedTypeNumber, expectedTypeName)
+  )
+}
+
 /**
  * Double SHA256 hash (SHA256d) - used by Dash for signing
  */
@@ -157,8 +185,8 @@ export async function buildUnsignedKeyRegistrationTransition(
   // Keep the auth key on the existing hash160 workaround, but register the
   // encryption key as a full secp256k1 public key so encrypted features can
   // consume the on-chain key material directly.
-  const authKeyType = 'ECDSA_HASH160' as const
-  const encryptionKeyType = 'ECDSA_SECP256K1' as const
+  const authKeyType = 'ecdsa_hash160' as const
+  const encryptionKeyType = 'ecdsa_secp256k1' as const
 
   const authKeyData = hash160(authPublicKey)
   const encryptionKeyData = encryptionPublicKey
@@ -176,8 +204,8 @@ export async function buildUnsignedKeyRegistrationTransition(
   )
   const authKey = new wasm.IdentityPublicKeyInCreation({
     keyId: authKeyId,
-    purpose: 'AUTHENTICATION',
-    securityLevel: 'HIGH',
+    purpose: 'authentication',
+    securityLevel: 'high',
     keyType: authKeyType,
     isReadOnly: false,
     data: authKeyData,
@@ -186,8 +214,8 @@ export async function buildUnsignedKeyRegistrationTransition(
 
   const encryptionKey = new wasm.IdentityPublicKeyInCreation({
     keyId: encryptionKeyId,
-    purpose: 'ENCRYPTION',
-    securityLevel: 'MEDIUM',
+    purpose: 'encryption',
+    securityLevel: 'medium',
     keyType: encryptionKeyType,
     isReadOnly: false,
     data: encryptionKeyData,
@@ -234,8 +262,8 @@ export async function buildUnsignedKeyRegistrationTransition(
   )
   const authKeyWithSig = new wasm.IdentityPublicKeyInCreation({
     keyId: authKeyId,
-    purpose: 'AUTHENTICATION',
-    securityLevel: 'HIGH',
+    purpose: 'authentication',
+    securityLevel: 'high',
     keyType: authKeyType,
     isReadOnly: false,
     data: authKeyData,
@@ -244,8 +272,8 @@ export async function buildUnsignedKeyRegistrationTransition(
 
   const encryptionKeyWithSig = new wasm.IdentityPublicKeyInCreation({
     keyId: encryptionKeyId,
-    purpose: 'ENCRYPTION',
-    securityLevel: 'MEDIUM',
+    purpose: 'encryption',
+    securityLevel: 'medium',
     keyType: encryptionKeyType,
     isReadOnly: false,
     data: encryptionKeyData,
@@ -311,7 +339,7 @@ export async function checkKeysRegistered(
   // Helper to extract key data as Uint8Array from a WASM IdentityPublicKey.
   // The WASM `.data` getter returns a hex string; `.toJSON().data` may differ.
   // Try the direct `.data` hex property first, then toJSON as fallback.
-  const getKeyData = (key: { data?: string; toJSON: () => { data: string | Uint8Array } }): Uint8Array => {
+  const getKeyData = (key: RegisteredIdentityKey): Uint8Array => {
     // Prefer the direct .data hex getter from WASM objects
     const raw = key.data ?? key.toJSON().data
     if (raw instanceof Uint8Array) {
@@ -337,9 +365,9 @@ export async function checkKeysRegistered(
 
   const authHash = hash160(authPublicKey)
 
-  // Check for auth key (purpose='AUTHENTICATION')
-  const authKeyExists = publicKeys.some((key: { purpose: string; keyType: string; data?: string; toJSON: () => { data: string | Uint8Array } }) => {
-    if (key.purpose !== 'AUTHENTICATION' || key.keyType !== 'ECDSA_HASH160') {
+  // Check for auth key (purpose=AUTHENTICATION, keyType=ECDSA_HASH160)
+  const authKeyExists = publicKeys.some((key: RegisteredIdentityKey) => {
+    if (!keyMatchesPurposeAndType(key, 0, 'authentication', 2, 'ecdsa_hash160')) {
       return false
     }
     const keyData = getKeyData(key)
@@ -349,9 +377,9 @@ export async function checkKeysRegistered(
     return keyData.every((b: number, i: number) => b === authHash[i])
   })
 
-  // Check for encryption key (purpose='ENCRYPTION')
-  const encKeyExists = publicKeys.some((key: { purpose: string; keyType: string; data?: string; toJSON: () => { data: string | Uint8Array } }) => {
-    if (key.purpose !== 'ENCRYPTION' || key.keyType !== 'ECDSA_SECP256K1') {
+  // Check for encryption key (purpose=ENCRYPTION, keyType=ECDSA_SECP256K1)
+  const encKeyExists = publicKeys.some((key: RegisteredIdentityKey) => {
+    if (!keyMatchesPurposeAndType(key, 1, 'encryption', 0, 'ecdsa_secp256k1')) {
       return false
     }
     const keyData = getKeyData(key)

--- a/lib/services/profile-service.ts
+++ b/lib/services/profile-service.ts
@@ -1,6 +1,6 @@
 import { logger } from '@/lib/logger';
 import { BaseDocumentService, QueryOptions, DocumentResult } from './document-service';
-import type { DocumentWhereClause, DocumentOrderByClause } from './sdk-helpers';
+import { documentToPlainObject, type DocumentWhereClause, type DocumentOrderByClause } from './sdk-helpers';
 import { User } from '../../types';
 import { dpnsService } from './dpns-service';
 import { cacheManager } from '../cache-manager';
@@ -78,10 +78,7 @@ class ProfileService extends BaseDocumentService<User> {
         const entries = Array.from(response.values());
         for (const doc of entries) {
           if (doc) {
-            const d = doc as { toJSON?: () => unknown };
-            const docData = typeof d.toJSON === 'function'
-              ? d.toJSON()
-              : doc;
+            const docData = documentToPlainObject(doc);
             documents.push(this.transformDocument(docData as Record<string, unknown>, { cachedUsername: this.cachedUsername }));
           }
         }
@@ -96,16 +93,21 @@ class ProfileService extends BaseDocumentService<User> {
       let result: Record<string, unknown> | unknown[] = response as Record<string, unknown>;
 
       // Handle different response formats
-      const respObj = response as { toJSON?: () => unknown };
-      if (response && typeof respObj.toJSON === 'function') {
+      const respObj = response as { toObject?: () => unknown; toJSON?: () => unknown };
+      if (response && typeof respObj.toObject === 'function') {
+        result = documentToPlainObject(response);
+      } else if (response && typeof respObj.toJSON === 'function') {
         result = respObj.toJSON() as Record<string, unknown>;
       }
 
       // Check if result is an array (direct documents response)
       if (Array.isArray(result)) {
-        const documents = result.map((doc) => {
-          return this.transformDocument(doc as Record<string, unknown>, { cachedUsername: this.cachedUsername });
-        });
+        const documents = result
+          .filter(Boolean)
+          .map(documentToPlainObject)
+          .map((doc) => {
+            return this.transformDocument(doc as Record<string, unknown>, { cachedUsername: this.cachedUsername });
+          });
 
         return {
           documents,
@@ -116,9 +118,12 @@ class ProfileService extends BaseDocumentService<User> {
 
       // Otherwise expect object with documents property
       const resultObj = result as { documents?: unknown[]; nextCursor?: string; prevCursor?: string };
-      const documents = resultObj?.documents?.map((doc) => {
-        return this.transformDocument(doc as Record<string, unknown>, { cachedUsername: this.cachedUsername });
-      }) || [];
+      const documents = resultObj?.documents
+        ?.filter(Boolean)
+        .map(documentToPlainObject)
+        .map((doc) => {
+          return this.transformDocument(doc as Record<string, unknown>, { cachedUsername: this.cachedUsername });
+        }) || [];
 
       return {
         documents,
@@ -452,22 +457,26 @@ class ProfileService extends BaseDocumentService<User> {
       if (response instanceof Map) {
         const documents = Array.from(response.values())
           .filter(Boolean)
-          .map((doc: unknown) => {
-            const d = doc as { toJSON?: () => unknown };
-            return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as ProfileDocument;
-          });
+          .map((doc: unknown) => documentToPlainObject(doc) as unknown as ProfileDocument);
         logger.info(`ProfileService: Found ${documents.length} profiles`);
         return documents;
       }
 
-      // Handle array response
-      const respWithDocs = response as { documents?: ProfileDocument[] };
-      if (Array.isArray(response)) {
-        logger.info(`ProfileService: Found ${(response as ProfileDocument[]).length} profiles`);
-        return response as ProfileDocument[];
-      } else if (respWithDocs?.documents) {
-        logger.info(`ProfileService: Found ${respWithDocs.documents.length} profiles`);
-        return respWithDocs.documents;
+      // Handle fallback response shapes
+      const fallbackResponse = response as unknown;
+      const respWithDocs = fallbackResponse as { documents?: unknown[] };
+      if (Array.isArray(fallbackResponse)) {
+        const documents = fallbackResponse
+          .filter(Boolean)
+          .map((doc: unknown) => documentToPlainObject(doc) as unknown as ProfileDocument);
+        logger.info(`ProfileService: Found ${documents.length} profiles`);
+        return documents;
+      } else if (Array.isArray(respWithDocs?.documents)) {
+        const documents = respWithDocs.documents
+          .filter(Boolean)
+          .map((doc: unknown) => documentToPlainObject(doc) as unknown as ProfileDocument);
+        logger.info(`ProfileService: Found ${documents.length} profiles`);
+        return documents;
       }
 
       return [];

--- a/lib/services/sdk-helpers.ts
+++ b/lib/services/sdk-helpers.ts
@@ -80,8 +80,20 @@ export function identifierToBase58(value: unknown): string | null {
     return bs58.encode(new Uint8Array(value));
   }
 
-  // Identifier object from SDK (has toBuffer or bytes method)
-  const obj = value as { toBuffer?: () => Uint8Array; bytes?: Uint8Array; toJSON?: () => unknown };
+  // Identifier object from SDK
+  const obj = value as {
+    toBase58?: () => string;
+    toBytes?: () => Uint8Array;
+    toBuffer?: () => Uint8Array;
+    bytes?: Uint8Array;
+    toJSON?: () => unknown;
+  };
+  if (typeof obj.toBase58 === 'function') {
+    return obj.toBase58();
+  }
+  if (typeof obj.toBytes === 'function') {
+    return bs58.encode(obj.toBytes());
+  }
   if (typeof obj.toBuffer === 'function') {
     return bs58.encode(obj.toBuffer());
   }
@@ -92,6 +104,9 @@ export function identifierToBase58(value: unknown): string | null {
   // Try toJSON which might return bytes
   if (typeof obj.toJSON === 'function') {
     const json = obj.toJSON();
+    if (typeof json === 'string') {
+      return identifierToBase58(json);
+    }
     if (json instanceof Uint8Array) {
       return bs58.encode(json);
     }
@@ -134,6 +149,51 @@ export function requireDocumentIdentifierBytes(id: string, fieldName: string): U
  * Prefer `requireDocumentIdentifierBytes` in new code so the typed-write intent stays obvious.
  */
 export const requireIdentifierBytes = requireDocumentIdentifierBytes
+
+const DOCUMENT_SYSTEM_IDENTIFIER_FIELDS = new Set(['$id', '$ownerId', '$dataContractId']);
+const DOCUMENT_SYSTEM_BIGINT_FIELDS = new Set([
+  '$revision',
+  '$createdAt',
+  '$updatedAt',
+  '$transferredAt',
+  '$createdAtBlockHeight',
+  '$updatedAtBlockHeight',
+  '$transferredAtBlockHeight',
+]);
+
+function normalizeDocumentSystemValue(field: string, value: unknown): unknown {
+  if (DOCUMENT_SYSTEM_IDENTIFIER_FIELDS.has(field)) {
+    return identifierToBase58(value) ?? value;
+  }
+
+  if (DOCUMENT_SYSTEM_BIGINT_FIELDS.has(field) && typeof value === 'bigint') {
+    const asNumber = Number(value);
+    return Number.isSafeInteger(asNumber) ? asNumber : value.toString();
+  }
+
+  return value;
+}
+
+/**
+ * Convert a WASM Document instance to the JSON-like shape Yappr expects from queries.
+ * `Document#toJSON()` now needs a platform version, so normalize the zero-arg
+ * `toObject()` output without rewriting ordinary Uint8Array content fields.
+ */
+export function documentToPlainObject(doc: unknown): Record<string, unknown> {
+  const document = doc as { toObject?: () => unknown };
+  const raw = (typeof document.toObject === 'function' ? document.toObject() : doc) as Record<string, unknown>;
+
+  if (!raw || typeof raw !== 'object') {
+    return raw;
+  }
+
+  return Object.fromEntries(
+    Object.entries(raw).map(([field, value]) => [
+      field,
+      normalizeDocumentSystemValue(field, value),
+    ])
+  );
+}
 
 /**
  * Convert an array of identifier strings to raw bytes.
@@ -380,11 +440,7 @@ export function mapToDocumentArray(
 
   for (const doc of values) {
     if (doc) {
-      // Document has a toJSON method that returns the plain object
-      const data = typeof (doc as { toJSON?: () => unknown }).toJSON === 'function'
-        ? (doc as { toJSON: () => unknown }).toJSON()
-        : doc;
-      documents.push(data as Record<string, unknown>);
+      documents.push(documentToPlainObject(doc));
     }
   }
 
@@ -404,32 +460,37 @@ export function normalizeSDKResponse(response: unknown): Record<string, unknown>
   if (response instanceof Map) {
     return Array.from(response.values())
       .filter(Boolean)
-      .map((doc: unknown) => {
-        const d = doc as { toJSON?: () => unknown };
-        return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as Record<string, unknown>;
-      });
+      .map(documentToPlainObject);
   }
 
   // Handle Array response
   if (Array.isArray(response)) {
-    return response as Record<string, unknown>[];
+    return response
+      .filter(Boolean)
+      .map(documentToPlainObject);
+  }
+
+  // Handle a single WASM Document response
+  const maybeDocument = response as { toObject?: () => unknown };
+  if (typeof maybeDocument.toObject === 'function') {
+    return [documentToPlainObject(response)];
   }
 
   // Handle object with documents property
   const obj = response as { documents?: unknown[]; toJSON?: () => unknown };
   if (obj.documents && Array.isArray(obj.documents)) {
-    return obj.documents as Record<string, unknown>[];
+    return obj.documents.map(documentToPlainObject);
   }
 
-  // Handle object with toJSON method
+  // Handle object with toJSON method for legacy response wrappers
   if (typeof obj.toJSON === 'function') {
     const json = obj.toJSON();
     if (Array.isArray(json)) {
-      return json as Record<string, unknown>[];
+      return json.map(documentToPlainObject);
     }
     const jsonObj = json as { documents?: unknown[] };
     if (jsonObj.documents && Array.isArray(jsonObj.documents)) {
-      return jsonObj.documents as Record<string, unknown>[];
+      return jsonObj.documents.map(documentToPlainObject);
     }
   }
 

--- a/lib/services/signer-service.ts
+++ b/lib/services/signer-service.ts
@@ -13,6 +13,7 @@ import {
   IdentitySigner,
   PrivateKey,
   IdentityPublicKey,
+  PlatformVersion,
 } from '@dashevo/evo-sdk';
 import type { IdentityPublicKey as IdentityPublicKeyType } from './identity-service';
 import type { IdentityPublicKey as WasmIdentityPublicKey } from '@dashevo/wasm-sdk/compressed';
@@ -128,9 +129,9 @@ class SignerService {
     await ensureWasmReady();
 
     // Normalize the key data to match the expected JSON format
-    // v3.1: SDK consistently returns camelCase, requires $version field
+    // v3.1: SDK consistently returns camelCase, requires $formatVersion field
     const normalizedKeyData = {
-      $version: '0',
+      $formatVersion: '0',
       id: keyData.id,
       type: keyData.type,
       purpose: keyData.purpose,
@@ -143,7 +144,10 @@ class SignerService {
 
     // Use the fromJSON method which handles proper deserialization
     // Cast needed: TS can't narrow the ternary on data to string
-    const identityKey = IdentityPublicKey.fromJSON(normalizedKeyData as Parameters<typeof IdentityPublicKey.fromJSON>[0]);
+    const identityKey = IdentityPublicKey.fromJSON(
+      normalizedKeyData as Parameters<typeof IdentityPublicKey.fromJSON>[0],
+      PlatformVersion.current()
+    );
 
     return identityKey;
   }

--- a/lib/services/state-transition-service.ts
+++ b/lib/services/state-transition-service.ts
@@ -6,6 +6,7 @@ import { findMatchingKeyIndex, getSecurityLevelName, type IdentityPublicKeyInfo 
 import type { IdentityPublicKey as WasmIdentityPublicKey } from '@dashevo/wasm-sdk/compressed';
 import { promptForAuthKey } from '../auth-utils';
 import { extractErrorMessage, isTimeoutError, isAlreadyExistsError, isNonFatalWaitError } from '../error-utils';
+import { documentToPlainObject } from './sdk-helpers';
 import {
   DocumentCreateTransition,
   BatchedTransition,
@@ -250,8 +251,8 @@ class StateTransitionService {
     try {
       const doc = await sdk.documents.get(contractId, documentType, documentId);
       if (doc) {
-        const json = typeof doc.toJSON === 'function' ? doc.toJSON() : doc;
-        return json as Record<string, unknown>;
+        // Normalize zero-arg toObject() output back to the JSON-like shape Yappr expects.
+        return documentToPlainObject(doc);
       }
       return null;
     } catch (err) {

--- a/lib/services/unified-profile-service.ts
+++ b/lib/services/unified-profile-service.ts
@@ -5,6 +5,7 @@ import { cacheManager } from '../cache-manager';
 import { YAPPR_PROFILE_CONTRACT_ID } from '../constants';
 import { User, ParsedPaymentUri, SocialLink } from '../../types';
 import { generateAvatarDataUri } from './avatar-generator';
+import { documentToPlainObject } from './sdk-helpers';
 
 // Approved payment URI schemes (whitelist)
 export const APPROVED_PAYMENT_SCHEMES = [
@@ -427,21 +428,17 @@ class UnifiedProfileService extends BaseDocumentService<User> {
     if (response instanceof Map) {
       return Array.from(response.values())
         .filter(Boolean)
-        .map((doc: unknown) => {
-          const d = doc as { toJSON?: () => unknown };
-          return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as Record<string, unknown>;
-        });
+        .map(documentToPlainObject);
     }
     if (Array.isArray(response)) {
       return response
         .filter(Boolean)
-        .map((doc: unknown) => {
-          const d = doc as { toJSON?: () => unknown };
-          return (typeof d.toJSON === 'function' ? d.toJSON() : doc) as Record<string, unknown>;
-        });
+        .map(documentToPlainObject);
     }
     if (response && typeof response === 'object' && 'documents' in response) {
-      return (response as { documents: Record<string, unknown>[] }).documents;
+      return ((response as { documents: unknown[] }).documents || [])
+        .filter(Boolean)
+        .map(documentToPlainObject);
     }
     return [];
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@blocknote/core": "^0.47.0",
         "@blocknote/mantine": "^0.47.0",
         "@blocknote/react": "^0.47.0",
-        "@dashevo/evo-sdk": "3.1.0-dev.1",
+        "@dashevo/evo-sdk": "3.1.0-dev.8",
         "@dicebear/collection": "^9.2.4",
         "@dicebear/core": "^9.2.4",
         "@emoji-mart/data": "^1.2.1",
@@ -183,20 +183,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-afVJhPXkgrg2vlLgyAgcWqUeugXhA5XkfssQZWQGNXlZkH7/22yB9sd37UX+tWtvoqEjxKzygryzTngt1SI44w==",
+      "version": "3.1.0-dev.8",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.8.tgz",
+      "integrity": "sha512-2ecyGj/4fTyH+iwk2K09xQ77LBJSYuTCmS4vFqhx65XXyXVDW/ptNe2zJw12LiDVlh3OyJykiyj1vfu9bRLt0g==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "3.1.0-dev.1"
+        "@dashevo/wasm-sdk": "3.1.0-dev.8"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-s4ECro2+zCehfag7XVqbxrsDqOAZN2yMIGhMNjjeFesaOqOl1bUWffs3QMtEeuMZdYtKcZxUrlKsW1KlfLN/WQ==",
+      "version": "3.1.0-dev.8",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.8.tgz",
+      "integrity": "sha512-gOkaM4ACpvP1+2dAr6ESUG5+nNckCtFBg+OWI6EyvKkX1tkxxNuDTK/9J+2asHS7y1mTtp4axLhmnwF7UCNLeA==",
       "engines": {
         "node": ">=18.18"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@blocknote/core": "^0.47.0",
     "@blocknote/mantine": "^0.47.0",
     "@blocknote/react": "^0.47.0",
-    "@dashevo/evo-sdk": "3.1.0-dev.1",
+    "@dashevo/evo-sdk": "3.1.0-dev.8",
     "@dicebear/collection": "^9.2.4",
     "@dicebear/core": "^9.2.4",
     "@emoji-mart/data": "^1.2.1",


### PR DESCRIPTION
# fix: upgrade evo sdk for testnet proofs

## Summary

- Upgrade `@dashevo/evo-sdk` to exact `3.1.0-dev.8` for current Dash
  testnet proof/document compatibility.
- Replace zero-argument WASM `Document#toJSON()` query/fetch handling with
  centralized `documentToPlainObject()` normalization.
- Preserve JSON-like system IDs and timestamp/revision fields for Yappr
  callers across query, direct fetch, and fallback response shapes.
- Update identity key enum compatibility for dev.8 lowercase/numeric WASM key
  representations, including registration checks.

## Motivation

`yap.pr` was failing against latest testnet because the older SDK line no
longer matched current Platform proof/document behavior.

The dev.8 SDK keeps Yappr on the lower-risk `3.1` dev line while restoring
compatibility with current testnet responses.

## Validation

Run in a clean temporary checkout with this patch applied:

- `git diff --check`
- `npm install`
- `npm run lint`
  - Passed with existing warning noise.
  - Warnings included `react-hooks/exhaustive-deps`,
    `@typescript-eslint/no-explicit-any`, `@next/next/no-img-element`, and
    `@typescript-eslint/no-non-null-assertion`.
- `npm run build`
  - Passed.
- Direct SDK testnet smoke:
  - `sdk package 3.1.0-dev.8`
  - `wasm package 3.1.0-dev.8`
  - `connect OK`
  - `contract fetch OK true`
  - `document query OK 1`
- Focused normalization assertion for `documentToPlainObject()` covered
  Identifier and bigint system-field output.
- Pre-PR code review gate: `ship`.
- CodeRabbit findings were addressed and the final head was re-reviewed by the
  internal gate with `ship`.
- GitHub checks on the final head passed:
  - `Lint`
  - `Type Check`
  - `Build`
  - `Cloudflare Pages`
- Live Cloudflare preview smoke passed:
  - `https://fix-evo-sdk-dev8.yappr.pages.dev/feed/` loaded testnet feed
    content instead of staying on the Platform connection screen.

## Notes

The local pre-commit hook was skipped for the final amend because linting inside
the nested worktree hits a parent ESLint config conflict:

```text
Plugin "@typescript-eslint" was conflicted between ".eslintrc.json" and "../../../.eslintrc.json".
```

The clean temporary checkout lint/build above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document normalization across SDK responses to ensure consistent data handling.
  * Enhanced identity key processing with more reliable detection logic.

* **Chores**
  * Updated Dash Platform SDK dependency to `3.1.0-dev.8`.
  * Consolidated internal document conversion helpers for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->